### PR TITLE
Cmd ctx cancel

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -85,6 +85,12 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("failed to setup driver: " + err.Error())
 			}
 
+			go func() {
+				<-ctx.Done()
+				log.Info("shutting down driver", "context", ctx.Err())
+				d.Stop()
+			}()
+
 			log.Info("running driver")
 			if err := d.Run(); err != nil {
 				return fmt.Errorf("failed running driver: " + err.Error())


### PR DESCRIPTION
Branched from #50 

Catches context cancel so we can shutdown the driver and exit gracefully

@munnerz 


```release-note
NONE
```