### PR TITLE
Fs group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,20 +34,20 @@ all: verify build image ## runs test, build and image build
 clean: ## clean all bin data
 	rm -rf ./bin
 
-build: ## build cert-manager-csi
+build: ## build cert-manager-csi-driver
 	mkdir -p $(BINDIR)
-	GO111MODULE=on CGO_ENABLED=0 go build -v -o ./bin/cert-manager-csi ./cmd/.
+	GO111MODULE=on CGO_ENABLED=0 go build -v -o ./bin/cert-manager-csi-driver ./cmd/.
 
 verify: test boilerplate ## verify codebase
 
-test: ## offline test cert-manager-csi
+test: ## offline test cert-manager-csi-driver
 	go test -v ./pkg/...
 
 boilerplate: ## verify boilerplate headers
 	./hack/verify-boilerplate.sh
 
-image: build ## build cert-manager-csi docker image
-	docker build -t quay.io/jetstack/cert-manager-csi:v0.1.0 .
+image: build ## build cert-manager-csi-driver docker image
+	docker build -t quay.io/jetstack/cert-manager-csi-driver:v0.1.0 .
 
 e2e: depend ## run end to end tests
 	./test/run.sh

--- a/README.md
+++ b/README.md
@@ -132,23 +132,24 @@ The csi-driver driver aims to have complete feature parity with all possible
 values available through the cert-manager API however currently supports the
 following values;
 
-| Attribute                               | Description                                                                                           | Default                              | Example                          |
-|-----------------------------------------|-------------------------------------------------------------------------------------------------------|--------------------------------------|----------------------------------|
-| `csi.cert-manager.io/issuer-name`       | The Issuer name to sign the certificate request.                                                      |                                      | `ca-issuer`                      |
-| `csi.cert-manager.io/issuer-kind`       | The Issuer kind to sign the certificate request.                                                      | `Issuer`                             | `ClusterIssuer`                  |
-| `csi.cert-manager.io/issuer-group`      | The group name the Issuer belongs to.                                                                 | `cert-manager.io`                    | `out.of.tree.foo`                |
-| `csi.cert-manager.io/common-name`       | Certificate common name.                                                                              |                                      | `my-cert.foo`                    |
-| `csi.cert-manager.io/dns-names`         | DNS names the certificate will be requested for. At least a DNS Name, IP or URI name must be present. |                                      | `a.b.foo.com,c.d.foo.com`        |
-| `csi.cert-manager.io/ip-sans`           | IP addresses the certificate will be requested for.                                                   |                                      | `192.0.0.1,192.0.0.2`            |
-| `csi.cert-manager.io/uri-sans`          | URI names the certificate will be requested for.                                                      |                                      | `spiffe://foo.bar.cluster.local` |
-| `csi.cert-manager.io/duration`          | Requested duration the signed certificate will be valid for.                                          | `720h`                               | `1880h`                          |
-| `csi.cert-manager.io/is-ca`             | Mark the certificate as a certificate authority.                                                      | `false`                              | `true`                           |
-| `csi.cert-manager.io/key-usages`        | Set the key usages on the certificate request.                                                        | `digital signature,key encipherment` | `server auth,client auth`        |
-| `csi.cert-manager.io/certificate-file`  | File name to store the certificate file at.                                                           | `tls.crt`                            | `bar/foo.crt`                    |
-| `csi.cert-manager.io/ca-file`           | File name to store the ca certificate file at.                                                        | `ca.crt`                             | `bar/foo.ca`                     |
-| `csi.cert-manager.io/privatekey-file`   | File name to store the key file at.                                                                   | `tls.key`                            | `bar/foo.key`                    |
-| `csi.cert-manager.io/renew-before`      | The time to renew the certificate before expiry. Defaults to a third of the requested duration.       | `$CERT_DURATION/3`                   | `72h`                            |
-| `csi.cert-manager.io/reuse-private-key` | Re-use the same private when when renewing certificates.                                              | `false`                              | `true`                           |
+| Attribute                               | Description                                                                                                           | Default                              | Example                          |
+|-----------------------------------------|-----------------------------------------------------------------------------------------------------------------------|--------------------------------------|----------------------------------|
+| `csi.cert-manager.io/issuer-name`       | The Issuer name to sign the certificate request.                                                                      |                                      | `ca-issuer`                      |
+| `csi.cert-manager.io/issuer-kind`       | The Issuer kind to sign the certificate request.                                                                      | `Issuer`                             | `ClusterIssuer`                  |
+| `csi.cert-manager.io/issuer-group`      | The group name the Issuer belongs to.                                                                                 | `cert-manager.io`                    | `out.of.tree.foo`                |
+| `csi.cert-manager.io/common-name`       | Certificate common name.                                                                                              |                                      | `my-cert.foo`                    |
+| `csi.cert-manager.io/dns-names`         | DNS names the certificate will be requested for. At least a DNS Name, IP or URI name must be present.                 |                                      | `a.b.foo.com,c.d.foo.com`        |
+| `csi.cert-manager.io/ip-sans`           | IP addresses the certificate will be requested for.                                                                   |                                      | `192.0.0.1,192.0.0.2`            |
+| `csi.cert-manager.io/uri-sans`          | URI names the certificate will be requested for.                                                                      |                                      | `spiffe://foo.bar.cluster.local` |
+| `csi.cert-manager.io/duration`          | Requested duration the signed certificate will be valid for.                                                          | `720h`                               | `1880h`                          |
+| `csi.cert-manager.io/is-ca`             | Mark the certificate as a certificate authority.                                                                      | `false`                              | `true`                           |
+| `csi.cert-manager.io/key-usages`        | Set the key usages on the certificate request.                                                                        | `digital signature,key encipherment` | `server auth,client auth`        |
+| `csi.cert-manager.io/certificate-file`  | File name to store the certificate file at.                                                                           | `tls.crt`                            | `bar/foo.crt`                    |
+| `csi.cert-manager.io/ca-file`           | File name to store the ca certificate file at.                                                                        | `ca.crt`                             | `bar/foo.ca`                     |
+| `csi.cert-manager.io/privatekey-file`   | File name to store the key file at.                                                                                   | `tls.key`                            | `bar/foo.key`                    |
+| `csi.cert-manager.io/fs-group`          | Set the FS Group of written files. Should be paired with and match the value of the consuming container `runAsGroup`. |                                      | `2000`                           |
+| `csi.cert-manager.io/renew-before`      | The time to renew the certificate before expiry. Defaults to a third of the requested duration.                       | `$CERT_DURATION/3`                   | `72h`                            |
+| `csi.cert-manager.io/reuse-private-key` | Re-use the same private when when renewing certificates.                                                              | `false`                              | `true`                           |
 
 ## Design Documents
  - [Certificate Renewal](./docs/design/20190914.certificaterenewal.md)

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -71,6 +71,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				Store:         store,
 				Manager: manager.NewManagerOrDie(manager.Options{
 					Client:             opts.CMClient,
+					ClientForMetadata:  client.ClientForMetadataFunc(opts.RestConfig, opts.UseRequestToken),
 					MetadataReader:     store,
 					Clock:              clock.RealClock{},
 					Log:                opts.Logr.WithName("manager"),

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/cert-manager/csi-driver/cmd/app/options"
+	csiapi "github.com/cert-manager/csi-driver/pkg/apis/v1alpha1"
 	"github.com/cert-manager/csi-driver/pkg/filestore"
 	"github.com/cert-manager/csi-driver/pkg/keygen"
 	"github.com/cert-manager/csi-driver/pkg/requestgen"
@@ -60,6 +61,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to setup filesystem: %w")
 			}
+			store.FSGroupVolumeAttributeKey = csiapi.FSGroupKey
 
 			keyGenerator := keygen.Generator{Store: store}
 			writer := filestore.Writer{Store: store}

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -71,7 +71,6 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				Store:         store,
 				Manager: manager.NewManagerOrDie(manager.Options{
 					Client:             opts.CMClient,
-					ClientForMetadata:  client.ClientForMetadataFunc(opts.RestConfig, opts.UseRequestToken),
 					MetadataReader:     store,
 					Clock:              clock.RealClock{},
 					Log:                opts.Logr.WithName("manager"),

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -55,11 +55,6 @@ type Options struct {
 	// from.
 	DataRoot string
 
-	// UseRequestToken declares that the CSI driver will use the empty audience
-	// request token for creating CertificateRequests. Requires the request token
-	// to be defined on the CSIDriver manifest.
-	UseRequestToken bool
-
 	// Logr is the shared base logger.
 	Logr logr.Logger
 

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -55,6 +55,11 @@ type Options struct {
 	// from.
 	DataRoot string
 
+	// UseRequestToken declares that the CSI driver will use the empty audience
+	// request token for creating CertificateRequests. Requires the request token
+	// to be defined on the CSIDriver manifest.
+	UseRequestToken bool
+
 	// Logr is the shared base logger.
 	Logr logr.Logger
 
@@ -127,13 +132,18 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 		"log-level", "v", "1",
 		"Log level (1-5).")
 
-	fs.StringVar(&o.NodeID, "node-id", "", "The name of the node which is hosting this driver instance.")
+	fs.StringVar(&o.NodeID, "node-id", "",
+		"The name of the node which is hosting this driver instance.")
 
-	fs.StringVar(&o.Endpoint, "endpoint", "", "The endpoint that the driver will connect to the Kubelet.")
+	fs.StringVar(&o.Endpoint, "endpoint", "",
+		"The endpoint that the driver will connect to the Kubelet.")
 
-	fs.StringVar(&o.DriverName, "driver-name",
-		"csi.cert-manager.io", "The name of this CSI driver which will be shared with the Kubelet.")
+	fs.StringVar(&o.DriverName, "driver-name", "csi.cert-manager.io",
+		"The name of this CSI driver which will be shared with the Kubelet.")
 
-	fs.StringVar(&o.DataRoot, "data-root",
-		"/csi-data-dir", "The directory that the driver will write and mount volumes from.")
+	fs.StringVar(&o.DataRoot, "data-root", "/csi-data-dir",
+		"The directory that the driver will write and mount volumes from.")
+
+	fs.BoolVar(&o.UseRequestToken, "use-request-token", false,
+		"Use the empty audience request token for creating CertificateRequests. Requires the request token to be defined on the CSIDriver manifest.")
 }

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -132,18 +132,13 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 		"log-level", "v", "1",
 		"Log level (1-5).")
 
-	fs.StringVar(&o.NodeID, "node-id", "",
-		"The name of the node which is hosting this driver instance.")
+	fs.StringVar(&o.NodeID, "node-id", "", "The name of the node which is hosting this driver instance.")
 
-	fs.StringVar(&o.Endpoint, "endpoint", "",
-		"The endpoint that the driver will connect to the Kubelet.")
+	fs.StringVar(&o.Endpoint, "endpoint", "", "The endpoint that the driver will connect to the Kubelet.")
 
-	fs.StringVar(&o.DriverName, "driver-name", "csi.cert-manager.io",
-		"The name of this CSI driver which will be shared with the Kubelet.")
+	fs.StringVar(&o.DriverName, "driver-name",
+		"csi.cert-manager.io", "The name of this CSI driver which will be shared with the Kubelet.")
 
-	fs.StringVar(&o.DataRoot, "data-root", "/csi-data-dir",
-		"The directory that the driver will write and mount volumes from.")
-
-	fs.BoolVar(&o.UseRequestToken, "use-request-token", false,
-		"Use the empty audience request token for creating CertificateRequests. Requires the request token to be defined on the CSIDriver manifest.")
+	fs.StringVar(&o.DataRoot, "data-root",
+		"/csi-data-dir", "The directory that the driver will write and mount volumes from.")
 }

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -22,9 +22,9 @@ A Helm chart for cert-manager-csi-driver
 |-----|------|---------|-------------|
 | app.driver | object | `{"name":"csi.cert-manager.io"}` | Options for CSI driver |
 | app.driver.name | string | `"csi.cert-manager.io"` | Name of the driver which will be registered with Kubernetes. |
-| app.logLevel | int | `1` | Verbosity of cert-manager-csi logging. |
+| app.logLevel | int | `1` | Verbosity of cert-manager-csi-driver logging. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on DaemonSet. |
-| image.repository | string | `"quay.io/jetstack/cert-manager-csi"` | Target image repository. |
+| image.repository | string | `"quay.io/jetstack/cert-manager-csi-driver"` | Target image repository. |
 | image.tag | string | `"v0.1.0"` | Target image version tag. |
 | resources | object | `{}` |  |
 

--- a/deploy/charts/csi-driver/templates/_helpers.tpl
+++ b/deploy/charts/csi-driver/templates/_helpers.tpl
@@ -2,23 +2,23 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "cert-manager-csi.name" -}}
+{{- define "cert-manager-csi-driver.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "cert-manager-csi.chart" -}}
+{{- define "cert-manager-csi-driver.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Common labels
 */}}
-{{- define "cert-manager-csi.labels" -}}
-app.kubernetes.io/name: {{ include "cert-manager-csi.name" . }}
-helm.sh/chart: {{ include "cert-manager-csi.chart" . }}
+{{- define "cert-manager-csi-driver.labels" -}}
+app.kubernetes.io/name: {{ include "cert-manager-csi-driver.name" . }}
+helm.sh/chart: {{ include "cert-manager-csi-driver.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/deploy/charts/csi-driver/templates/clusterrole.yaml
+++ b/deploy/charts/csi-driver/templates/clusterrole.yaml
@@ -2,8 +2,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-{{ include "cert-manager-csi.labels" . | indent 4 }}
-  name: {{ include "cert-manager-csi.name" . }}
+{{ include "cert-manager-csi-driver.labels" . | indent 4 }}
+  name: {{ include "cert-manager-csi-driver.name" . }}
 rules:
 - apiGroups: ["cert-manager.io"]
   resources: ["certificaterequests"]

--- a/deploy/charts/csi-driver/templates/clusterrolebinding.yaml
+++ b/deploy/charts/csi-driver/templates/clusterrolebinding.yaml
@@ -2,13 +2,13 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-{{ include "cert-manager-csi.labels" . | indent 4 }}
-  name: {{ include "cert-manager-csi.name" . }}
+{{ include "cert-manager-csi-driver.labels" . | indent 4 }}
+  name: {{ include "cert-manager-csi-driver.name" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "cert-manager-csi.name" . }}
+  name: {{ include "cert-manager-csi-driver.name" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "cert-manager-csi.name" . }}
+  name: {{ include "cert-manager-csi-driver.name" . }}
   namespace: {{ .Release.Namespace }}

--- a/deploy/charts/csi-driver/templates/csidriver.yaml
+++ b/deploy/charts/csi-driver/templates/csidriver.yaml
@@ -3,7 +3,7 @@ kind: CSIDriver
 metadata:
   name: {{ .Values.app.driver.name }}
   labels:
-{{ include "cert-manager-csi.labels" . | indent 4 }}
+{{ include "cert-manager-csi-driver.labels" . | indent 4 }}
 spec:
   podInfoOnMount: true
   volumeLifecycleModes:

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "cert-manager-csi.name" . }}
+  name: {{ include "cert-manager-csi-driver.name" . }}
   labels:
-{{ include "cert-manager-csi.labels" . | indent 4 }}
+{{ include "cert-manager-csi-driver.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "cert-manager-csi.name" . }}
+      app: {{ include "cert-manager-csi-driver.name" . }}
   template:
     metadata:
       labels:
-        app: {{ include "cert-manager-csi.name" . }}
+        app: {{ include "cert-manager-csi-driver.name" . }}
     spec:
-      serviceAccountName: {{ include "cert-manager-csi.name" . }}
+      serviceAccountName: {{ include "cert-manager-csi-driver.name" . }}
       containers:
 
         - name: node-driver-registrar
@@ -21,11 +21,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/cert-manager-csi /registration/cert-manager-csi-reg.sock"]
+                command: ["/bin/sh", "-c", "rm -rf /registration/cert-manager-csi-driver /registration/cert-manager-csi-driver-reg.sock"]
           args:
             - -v={{ .Values.app.logLevel }}
             - --csi-address=/plugin/csi.sock
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/cert-manager-csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/cert-manager-csi-driver/csi.sock
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -37,7 +37,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
 
-        - name: cert-manager-csi
+        - name: cert-manager-csi-driver
           securityContext:
             privileged: true
             capabilities:
@@ -72,7 +72,7 @@ spec:
       volumes:
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/cert-manager-csi
+            path: /var/lib/kubelet/plugins/cert-manager-csi-driver
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
@@ -83,6 +83,6 @@ spec:
             type: Directory
           name: registration-dir
         - hostPath:
-            path: /tmp/cert-manager-csi
+            path: /tmp/cert-manager-csi-driver
             type: DirectoryOrCreate
           name: csi-data-dir

--- a/deploy/charts/csi-driver/templates/serviceaccount.yaml
+++ b/deploy/charts/csi-driver/templates/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-{{ include "cert-manager-csi.labels" . | indent 4 }}
-  name: {{ include "cert-manager-csi.name" . }}
+{{ include "cert-manager-csi-driver.labels" . | indent 4 }}
+  name: {{ include "cert-manager-csi-driver.name" . }}

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -32,6 +32,7 @@ const (
 	CAFileKey   = "csi.cert-manager.io/ca-file"
 	CertFileKey = "csi.cert-manager.io/certificate-file"
 	KeyFileKey  = "csi.cert-manager.io/privatekey-file"
+	FSGroupKey  = "csi.cert-manager.io/fs-group"
 
 	RenewBeforeKey  = "csi.cert-manager.io/renew-before"
 	ReusePrivateKey = "csi.cert-manager.io/reuse-private-key"

--- a/test/e2e/framework/testenv.go
+++ b/test/e2e/framework/testenv.go
@@ -94,7 +94,7 @@ tSK2ayFX1wQ3PuEmewAogy/20tWo80cr556AXA62Utl2PzLK30Db8w==
 func (f *Framework) CreateKubeNamespace(baseName string) (*corev1.Namespace, error) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("e2e-cert-manager-csi-tests-%v-", baseName),
+			GenerateName: fmt.Sprintf("e2e-cert-manager-csi-driver-tests-%v-", baseName),
 		},
 	}
 

--- a/test/e2e/suite/cases/fsgroup.go
+++ b/test/e2e/suite/cases/fsgroup.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cases
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	csi "github.com/jetstack/cert-manager-csi/pkg/apis"
+	"github.com/jetstack/cert-manager-csi/test/e2e/framework"
+	"github.com/jetstack/cert-manager-csi/test/e2e/util"
+)
+
+var _ = framework.CasesDescribe("Should pick-up correct FSGroup on Pods", func() {
+	f := framework.NewDefaultFramework("fs-group")
+
+	It("should create a pod with a Group of 2000 and be able to read files with FS Group of 2000", func() {
+		testVolume := corev1.Volume{
+			Name: "tls",
+			VolumeSource: corev1.VolumeSource{
+				CSI: &corev1.CSIVolumeSource{
+					Driver:   csi.GroupName,
+					ReadOnly: boolPtr(true),
+					VolumeAttributes: map[string]string{
+						"csi.cert-manager.io/issuer-name": f.Issuer.Name,
+						"csi.cert-manager.io/fs-group":    "2000",
+					},
+				},
+			},
+		}
+
+		var group int64 = 2000
+		testPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: f.BaseName + "-",
+				Namespace:    f.Namespace.Name,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					corev1.Container{
+						Name:    "test-container-1",
+						Image:   "busybox",
+						Command: []string{"sleep", "10000"},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/tls",
+								Name:      "tls",
+							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							RunAsGroup: &group,
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					testVolume,
+				},
+			},
+		}
+
+		By("Creating a Pod")
+		testPod, err := f.KubeClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), testPod, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Pod to become ready")
+		err = f.Helper().WaitForPodReady(f.Namespace.Name, testPod.Name, time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensure the corresponding CertificateRequest should exist with the correct spec")
+		crs, err := f.Helper().WaitForCertificateRequestsReady(testPod, time.Second)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = util.CertificateRequestMatchesSpec(crs[0], testVolume.CSI.VolumeAttributes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(crs).To(HaveLen(1))
+
+		By("Ensure the certificate key pair exists in the pod and can be read by the pod")
+		certData, keyData, err := f.Helper().CertificateKeyInPodPath(f.Namespace.Name, testPod.Name, "test-container-1", "/tls",
+			testVolume.CSI.VolumeAttributes)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensure certificate key pair matches spec")
+		err = f.Helper().CertificateKeyMatch(crs[0], certData, keyData)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/test/e2e/suite/cases/fsgroup.go
+++ b/test/e2e/suite/cases/fsgroup.go
@@ -26,9 +26,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	csi "github.com/jetstack/cert-manager-csi/pkg/apis"
-	"github.com/jetstack/cert-manager-csi/test/e2e/framework"
-	"github.com/jetstack/cert-manager-csi/test/e2e/util"
+	csi "github.com/cert-manager/csi-driver/pkg/apis"
+	"github.com/cert-manager/csi-driver/test/e2e/framework"
+	"github.com/cert-manager/csi-driver/test/e2e/util"
 )
 
 var _ = framework.CasesDescribe("Should pick-up correct FSGroup on Pods", func() {

--- a/test/e2e/suite/cases/fsgroup.go
+++ b/test/e2e/suite/cases/fsgroup.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Jetstack cert-manager contributors.
+Copyright 2021 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Branched from #52 

Adds support for setting the `csi.cert-manager.io/fs-group` volume attribute to control the FS group of volume files.

@munnerz 

```release-note
NONE
```