### PR TITLE
Token request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,20 +34,20 @@ all: verify build image ## runs test, build and image build
 clean: ## clean all bin data
 	rm -rf ./bin
 
-build: ## build cert-manager-csi
+build: ## build cert-manager-csi-driver
 	mkdir -p $(BINDIR)
-	GO111MODULE=on CGO_ENABLED=0 go build -v -o ./bin/cert-manager-csi ./cmd/.
+	GO111MODULE=on CGO_ENABLED=0 go build -v -o ./bin/cert-manager-csi-driver ./cmd/.
 
 verify: test boilerplate ## verify codebase
 
-test: ## offline test cert-manager-csi
+test: ## offline test cert-manager-csi-driver
 	go test -v ./pkg/...
 
 boilerplate: ## verify boilerplate headers
 	./hack/verify-boilerplate.sh
 
-image: build ## build cert-manager-csi docker image
-	docker build -t quay.io/jetstack/cert-manager-csi:v0.1.0 .
+image: build ## build cert-manager-csi-driver docker image
+	docker build -t quay.io/jetstack/cert-manager-csi-driver:v0.1.0 .
 
 e2e: depend ## run end to end tests
 	./test/run.sh

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -71,6 +71,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				Store:         store,
 				Manager: manager.NewManagerOrDie(manager.Options{
 					Client:             opts.CMClient,
+					ClientForMetadata:  client.ClientForMetadataFunc(opts.RestConfig, opts.UseRequestToken),
 					MetadataReader:     store,
 					Clock:              clock.RealClock{},
 					Log:                opts.Logr.WithName("manager"),

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -55,6 +55,11 @@ type Options struct {
 	// from.
 	DataRoot string
 
+	// UseRequestToken declares that the CSI driver will use the empty audience
+	// request token for creating CertificateRequests. Requires the request token
+	// to be defined on the CSIDriver manifest.
+	UseRequestToken bool
+
 	// Logr is the shared base logger.
 	Logr logr.Logger
 
@@ -127,13 +132,18 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 		"log-level", "v", "1",
 		"Log level (1-5).")
 
-	fs.StringVar(&o.NodeID, "node-id", "", "The name of the node which is hosting this driver instance.")
+	fs.StringVar(&o.NodeID, "node-id", "",
+		"The name of the node which is hosting this driver instance.")
 
-	fs.StringVar(&o.Endpoint, "endpoint", "", "The endpoint that the driver will connect to the Kubelet.")
+	fs.StringVar(&o.Endpoint, "endpoint", "",
+		"The endpoint that the driver will connect to the Kubelet.")
 
-	fs.StringVar(&o.DriverName, "driver-name",
-		"csi.cert-manager.io", "The name of this CSI driver which will be shared with the Kubelet.")
+	fs.StringVar(&o.DriverName, "driver-name", "csi.cert-manager.io",
+		"The name of this CSI driver which will be shared with the Kubelet.")
 
-	fs.StringVar(&o.DataRoot, "data-root",
-		"/csi-data-dir", "The directory that the driver will write and mount volumes from.")
+	fs.StringVar(&o.DataRoot, "data-root", "/csi-data-dir",
+		"The directory that the driver will write and mount volumes from.")
+
+	fs.BoolVar(&o.UseRequestToken, "use-request-token", false,
+		"Use the empty audience request token for creating CertificateRequests. Requires the request token to be defined on the CSIDriver manifest.")
 }

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -55,10 +55,10 @@ type Options struct {
 	// from.
 	DataRoot string
 
-	// UseRequestToken declares that the CSI driver will use the empty audience
+	// UseTokenRequest declares that the CSI driver will use the empty audience
 	// request token for creating CertificateRequests. Requires the request token
 	// to be defined on the CSIDriver manifest.
-	UseRequestToken bool
+	UseTokenRequest bool
 
 	// Logr is the shared base logger.
 	Logr logr.Logger
@@ -144,6 +144,6 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.DataRoot, "data-root", "/csi-data-dir",
 		"The directory that the driver will write and mount volumes from.")
 
-	fs.BoolVar(&o.UseRequestToken, "use-request-token", false,
-		"Use the empty audience request token for creating CertificateRequests. Requires the request token to be defined on the CSIDriver manifest.")
+	fs.BoolVar(&o.UseTokenRequest, "use-token-request", false,
+		"Use the empty audience token request for creating CertificateRequests. Requires the token request to be defined on the CSIDriver manifest.")
 }

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -56,7 +56,7 @@ type Options struct {
 	DataRoot string
 
 	// UseTokenRequest declares that the CSI driver will use the empty audience
-	// request token for creating CertificateRequests. Requires the request token
+	// token request for creating CertificateRequests. Requires the token request
 	// to be defined on the CSIDriver manifest.
 	UseTokenRequest bool
 

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -22,9 +22,9 @@ A Helm chart for cert-manager-csi-driver
 |-----|------|---------|-------------|
 | app.driver | object | `{"name":"csi.cert-manager.io"}` | Options for CSI driver |
 | app.driver.name | string | `"csi.cert-manager.io"` | Name of the driver which will be registered with Kubernetes. |
-| app.logLevel | int | `1` | Verbosity of cert-manager-csi logging. |
+| app.logLevel | int | `1` | Verbosity of cert-manager-csi-driver logging. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on DaemonSet. |
-| image.repository | string | `"quay.io/jetstack/cert-manager-csi"` | Target image repository. |
+| image.repository | string | `"quay.io/jetstack/cert-manager-csi-driver"` | Target image repository. |
 | image.tag | string | `"v0.1.0"` | Target image version tag. |
 | resources | object | `{}` |  |
 

--- a/deploy/charts/csi-driver/templates/_helpers.tpl
+++ b/deploy/charts/csi-driver/templates/_helpers.tpl
@@ -2,23 +2,23 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "cert-manager-csi.name" -}}
+{{- define "cert-manager-csi-driver.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "cert-manager-csi.chart" -}}
+{{- define "cert-manager-csi-driver.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Common labels
 */}}
-{{- define "cert-manager-csi.labels" -}}
-app.kubernetes.io/name: {{ include "cert-manager-csi.name" . }}
-helm.sh/chart: {{ include "cert-manager-csi.chart" . }}
+{{- define "cert-manager-csi-driver.labels" -}}
+app.kubernetes.io/name: {{ include "cert-manager-csi-driver.name" . }}
+helm.sh/chart: {{ include "cert-manager-csi-driver.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/deploy/charts/csi-driver/templates/clusterrole.yaml
+++ b/deploy/charts/csi-driver/templates/clusterrole.yaml
@@ -2,8 +2,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-{{ include "cert-manager-csi.labels" . | indent 4 }}
-  name: {{ include "cert-manager-csi.name" . }}
+{{ include "cert-manager-csi-driver.labels" . | indent 4 }}
+  name: {{ include "cert-manager-csi-driver.name" . }}
 rules:
 - apiGroups: ["cert-manager.io"]
   resources: ["certificaterequests"]

--- a/deploy/charts/csi-driver/templates/clusterrolebinding.yaml
+++ b/deploy/charts/csi-driver/templates/clusterrolebinding.yaml
@@ -2,13 +2,13 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-{{ include "cert-manager-csi.labels" . | indent 4 }}
-  name: {{ include "cert-manager-csi.name" . }}
+{{ include "cert-manager-csi-driver.labels" . | indent 4 }}
+  name: {{ include "cert-manager-csi-driver.name" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "cert-manager-csi.name" . }}
+  name: {{ include "cert-manager-csi-driver.name" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "cert-manager-csi.name" . }}
+  name: {{ include "cert-manager-csi-driver.name" . }}
   namespace: {{ .Release.Namespace }}

--- a/deploy/charts/csi-driver/templates/csidriver.yaml
+++ b/deploy/charts/csi-driver/templates/csidriver.yaml
@@ -3,7 +3,7 @@ kind: CSIDriver
 metadata:
   name: {{ .Values.app.driver.name }}
   labels:
-{{ include "cert-manager-csi.labels" . | indent 4 }}
+{{ include "cert-manager-csi-driver.labels" . | indent 4 }}
 spec:
   podInfoOnMount: true
   volumeLifecycleModes:

--- a/deploy/charts/csi-driver/templates/csidriver.yaml
+++ b/deploy/charts/csi-driver/templates/csidriver.yaml
@@ -8,7 +8,7 @@ spec:
   podInfoOnMount: true
   volumeLifecycleModes:
   - Ephemeral
-{{- if .Values.app.driver.useRequestToken }}
+{{- if .Values.app.driver.useTokenRequest }}
   tokenRequests:
     - audience: ""
       expirationSeconds: 3600

--- a/deploy/charts/csi-driver/templates/csidriver.yaml
+++ b/deploy/charts/csi-driver/templates/csidriver.yaml
@@ -8,3 +8,9 @@ spec:
   podInfoOnMount: true
   volumeLifecycleModes:
   - Ephemeral
+{{- if .Values.app.driver.useRequestToken }}
+  tokenRequests:
+    - audience: ""
+      expirationSeconds: 3600
+  requiresRepublish: true
+{{- end }}

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -51,7 +51,7 @@ spec:
             - --node-id=$(NODE_ID)
             - --endpoint=$(CSI_ENDPOINT)
             - --data-root=csi-data-dir
-            - --use-token-request={{ .Values.app.driver.useRequestToken }}
+            - --use-token-request={{ .Values.app.driver.useTokenRequest }}
           env:
             - name: NODE_ID
               valueFrom:

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -51,6 +51,7 @@ spec:
             - --node-id=$(NODE_ID)
             - --endpoint=$(CSI_ENDPOINT)
             - --data-root=csi-data-dir
+            - --use-token-request={{ .Values.app.driver.useRequestToken }}
           env:
             - name: NODE_ID
               valueFrom:

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "cert-manager-csi.name" . }}
+  name: {{ include "cert-manager-csi-driver.name" . }}
   labels:
-{{ include "cert-manager-csi.labels" . | indent 4 }}
+{{ include "cert-manager-csi-driver.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "cert-manager-csi.name" . }}
+      app: {{ include "cert-manager-csi-driver.name" . }}
   template:
     metadata:
       labels:
-        app: {{ include "cert-manager-csi.name" . }}
+        app: {{ include "cert-manager-csi-driver.name" . }}
     spec:
-      serviceAccountName: {{ include "cert-manager-csi.name" . }}
+      serviceAccountName: {{ include "cert-manager-csi-driver.name" . }}
       containers:
 
         - name: node-driver-registrar
@@ -21,11 +21,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/cert-manager-csi /registration/cert-manager-csi-reg.sock"]
+                command: ["/bin/sh", "-c", "rm -rf /registration/cert-manager-csi-driver /registration/cert-manager-csi-driver-reg.sock"]
           args:
             - -v={{ .Values.app.logLevel }}
             - --csi-address=/plugin/csi.sock
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/cert-manager-csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/cert-manager-csi-driver/csi.sock
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -37,7 +37,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
 
-        - name: cert-manager-csi
+        - name: cert-manager-csi-driver
           securityContext:
             privileged: true
             capabilities:
@@ -72,7 +72,7 @@ spec:
       volumes:
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/cert-manager-csi
+            path: /var/lib/kubelet/plugins/cert-manager-csi-driver
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
@@ -83,6 +83,6 @@ spec:
             type: Directory
           name: registration-dir
         - hostPath:
-            path: /tmp/cert-manager-csi
+            path: /tmp/cert-manager-csi-driver
             type: DirectoryOrCreate
           name: csi-data-dir

--- a/deploy/charts/csi-driver/templates/serviceaccount.yaml
+++ b/deploy/charts/csi-driver/templates/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-{{ include "cert-manager-csi.labels" . | indent 4 }}
-  name: {{ include "cert-manager-csi.name" . }}
+{{ include "cert-manager-csi-driver.labels" . | indent 4 }}
+  name: {{ include "cert-manager-csi-driver.name" . }}

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -13,6 +13,10 @@ app:
   driver:
     # -- Name of the driver which will be registered with Kubernetes.
     name: csi.cert-manager.io
+    # -- If enabled, will use CSI request token for creating
+    # CertificateRequests. CertificateRequests will be created via mounting
+    # pod's service accounts.
+    useRequestToken: false
 
 resources: {}
   # -- Kubernetes pod resource limits for cert-manager-csi-driver

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -13,10 +13,10 @@ app:
   driver:
     # -- Name of the driver which will be registered with Kubernetes.
     name: csi.cert-manager.io
-    # -- If enabled, will use CSI request token for creating
+    # -- If enabled, will use CSI token request for creating
     # CertificateRequests. CertificateRequests will be created via mounting
     # pod's service accounts.
-    useRequestToken: false
+    useTokenRequest: false
 
 resources: {}
   # -- Kubernetes pod resource limits for cert-manager-csi-driver

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cert-manager/csi-driver
 go 1.16
 
 require (
-	github.com/cert-manager/csi-lib v0.0.0-20210809101349-dd8ae5d66f53
+	github.com/cert-manager/csi-lib v0.0.0-20210816103043-fe9b5eff41b7
 	github.com/go-logr/logr v0.4.0
 	github.com/jetstack/cert-manager v1.4.0
 	github.com/onsi/ginkgo v1.16.4

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cert-manager/csi-lib v0.0.0-20210809101349-dd8ae5d66f53 h1:MsyN6t22ajr1pxC35s9E0shgwl2DcrEdBDGwkwu6SpA=
-github.com/cert-manager/csi-lib v0.0.0-20210809101349-dd8ae5d66f53/go.mod h1:Q+ClN5kE558Z5cLqW0b4OkHQmq9BuC86aF7oQpJMx54=
+github.com/cert-manager/csi-lib v0.0.0-20210816103043-fe9b5eff41b7 h1:QzDZ0hevoC6qf2pN8ZW+vroR9AGERj2bGH0UVeetcS0=
+github.com/cert-manager/csi-lib v0.0.0-20210816103043-fe9b5eff41b7/go.mod h1:1+VH37Reyyj5Tvo7gCaQwW06pM5Ff1PSJOB0mx7T4oQ=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=

--- a/test/e2e/framework/testenv.go
+++ b/test/e2e/framework/testenv.go
@@ -94,7 +94,7 @@ tSK2ayFX1wQ3PuEmewAogy/20tWo80cr556AXA62Utl2PzLK30Db8w==
 func (f *Framework) CreateKubeNamespace(baseName string) (*corev1.Namespace, error) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("e2e-cert-manager-csi-tests-%v-", baseName),
+			GenerateName: fmt.Sprintf("e2e-cert-manager-csi-driver-tests-%v-", baseName),
 		},
 	}
 


### PR DESCRIPTION
Branched from #52 

Adds a CLI flag for optionally using the token request token when creating CertificateRequests.

This PR will currently fail since we are testing against kube v1.16. Once more of the other PRs have landed, I will setup testing against different kube versions and we can optionally test this feature based on the kube version.


```release-note
NONE
```