### PR TITLE
Bump storage API version v1beta1 -> v1

### DIFF
--- a/deploy/charts/csi-driver/templates/csidriver.yaml
+++ b/deploy/charts/csi-driver/templates/csidriver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: {{ .Values.app.driver.name }}

--- a/deploy/charts/csi-driver/templates/csidriver.yaml
+++ b/deploy/charts/csi-driver/templates/csidriver.yaml
@@ -1,4 +1,8 @@
+{{- if .Capabilities.APIVersions.Has "storage.k8s.io/v1/CSIDriver" }}
 apiVersion: storage.k8s.io/v1
+{{- else }}
+apiVersion: storage.k8s.io/v1beta1
+{{- end }}
 kind: CSIDriver
 metadata:
   name: {{ .Values.app.driver.name }}

--- a/deploy/example/example-app.yaml
+++ b/deploy/example/example-app.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: sandbox
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -11,7 +11,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ca-issuer
@@ -25,7 +25,7 @@ spec:
     kind: Issuer
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ca-issuer

--- a/test/run.sh
+++ b/test/run.sh
@@ -98,8 +98,8 @@ docker network create --driver=bridge --subnet=192.168.0.0/16 --gateway 192.168.
 sleep 2
 
 echo "Creating kind cluster named '$CLUSTER_NAME'"
-# Kind image at 1.16.15, compatible with kind v0.11.1
-kind create cluster --image=kindest/node@sha256:83067ed51bf2a3395b24687094e283a7c7c865ccc12a8b1d7aa673ba0c5e8861 --name="$CLUSTER_NAME"
+# Kind image with Kubernetes v1.22.compatible with kind v0.11.1
+kind create cluster --image=kindest/node@sha256:100b3558428386d1372591f8d62add85b900538d94db8e455b66ebaf05a3ca3a --name="$CLUSTER_NAME"
 export KUBECONFIG="$(kind get kubeconfig-path --name="$CLUSTER_NAME")"
 
 CERT_MANAGER_MANIFEST_URL="https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml"


### PR DESCRIPTION
This PR allows for the CSI driver to be deployed on Kubernetes 1.22 by selectively deploying the CSIDriver at `storage.k8s.io/v1` if it is available at that version ([from Kubernetes 1.19](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#storage-resources-v122 )), else deploys it at `storage.k8s.io/v1beta1`.

I've also bumped the Kubernetes version used in e2e tests 1.16 -> 1.22.

I've tested that this works on both a 1.16 and 1.22 kind clusters