### PR TITLE
Adds support for multi-arch images, bumps version to v0.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 BINDIR ?= $(CURDIR)/bin
 ARCH   ?= $(shell go env GOARCH)
 HELM_VERSION ?= 3.4.1
+IMAGE_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
@@ -46,8 +47,12 @@ test: ## offline test cert-manager-csi-driver
 boilerplate: ## verify boilerplate headers
 	./hack/verify-boilerplate.sh
 
-image: build ## build cert-manager-csi-driver docker image
-	docker build -t quay.io/jetstack/cert-manager-csi-driver:v0.1.0 .
+# image will only build and store the image locally, targeted in OCI format.
+# To actually push an image to the public repo, replace the `--output` flag and
+# arguments to `--push`.
+.PHONY: image
+image: ## build cert-manager-csi-driver docker image targeting all supported platforms
+	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver:v0.1.1 --output type=oci,dest=./bin/cert-manager-csi-driver-oci .
 
 e2e: depend ## run end to end tests
 	./test/run.sh

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -74,7 +74,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 
 			d, err := driver.New(opts.Endpoint, opts.Logr.WithName("driver"), driver.Options{
 				DriverName:    opts.DriverName,
-				DriverVersion: "v0.1.0",
+				DriverVersion: "v0.1.1",
 				NodeID:        opts.NodeID,
 				Store:         store,
 				Manager: manager.NewManagerOrDie(manager.Options{

--- a/deploy/charts/csi-driver/Chart.yaml
+++ b/deploy/charts/csi-driver/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 sources:
 - https://github.com/cert-manager/csi-driver
 
-appVersion: v0.1.0
-version: v0.1.0
+appVersion: v0.1.1
+version: v0.1.1

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -1,6 +1,6 @@
 # cert-manager-csi-driver
 
-![Version: v0.1.0](https://img.shields.io/badge/Version-v0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: v0.1.1](https://img.shields.io/badge/Version-v0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1](https://img.shields.io/badge/AppVersion-v0.1.1-informational?style=flat-square)
 
 A Helm chart for cert-manager-csi-driver
 
@@ -20,11 +20,12 @@ A Helm chart for cert-manager-csi-driver
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| app.driver | object | `{"name":"csi.cert-manager.io"}` | Options for CSI driver |
+| app.driver | object | `{"name":"csi.cert-manager.io","useTokenRequest":false}` | Options for CSI driver |
 | app.driver.name | string | `"csi.cert-manager.io"` | Name of the driver which will be registered with Kubernetes. |
+| app.driver.useTokenRequest | bool | `false` | If enabled, will use CSI token request for creating CertificateRequests. CertificateRequests will be created via mounting pod's service accounts. |
 | app.logLevel | int | `1` | Verbosity of cert-manager-csi-driver logging. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on DaemonSet. |
 | image.repository | string | `"quay.io/jetstack/cert-manager-csi-driver"` | Target image repository. |
-| image.tag | string | `"v0.1.0"` | Target image version tag. |
+| image.tag | string | `"v0.1.1"` | Target image version tag. |
 | resources | object | `{}` |  |
 

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -2,7 +2,7 @@ image:
   # -- Target image repository.
   repository: quay.io/jetstack/cert-manager-csi-driver
   # -- Target image version tag.
-  tag: v0.1.0
+  tag: v0.1.1
   # -- Kubernetes imagePullPolicy on DaemonSet.
   pullPolicy: IfNotPresent
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -102,12 +102,9 @@ echo "Creating kind cluster named '$CLUSTER_NAME'"
 kind create cluster --image=kindest/node@sha256:83067ed51bf2a3395b24687094e283a7c7c865ccc12a8b1d7aa673ba0c5e8861 --name="$CLUSTER_NAME"
 export KUBECONFIG="$(kind get kubeconfig-path --name="$CLUSTER_NAME")"
 
-CERT_MANAGER_MANIFEST_URL="https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml"
+CERT_MANAGER_MANIFEST_URL="https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml"
 echo "Installing cert-manager in test cluster using manifest URL '$CERT_MANAGER_MANIFEST_URL'"
 kubectl create -f "$CERT_MANAGER_MANIFEST_URL"
-
-echo "Building cert-manager-csi-driver binary"
-CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o ./bin/cert-manager-csi-driver ./cmd
 
 CERT_MANAGER_CSI_DOCKER_IMAGE="quay.io/jetstack/cert-manager-csi-driver"
 CERT_MANAGER_CSI_DOCKER_TAG="canary"


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

Adds support for more platform architectures.

Bumps the image version to `v0.1.1`.

Should be merged after #59 

/hold
/assign @irbekrm @jakexks 