### PR TITLE
Use k8s.gcr.io repo for csi-node-driver-registrar

### DIFF
--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
 
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
This seems to be where the project is pushing images now. I have left
the version the same.

This repo has multi-arch image for this version which I need.

https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/eu/sig-storage%2Fcsi-node-driver-registrar@sha256:a61d309da54641db41fb8f35718f744e9f730d4d0384f8c4b186ddc9f06cbd5f/details?tab=pull

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>