### PR TITLE
Updates helm chart to v0.1.2

### DIFF
--- a/deploy/charts/csi-driver/Chart.yaml
+++ b/deploy/charts/csi-driver/Chart.yaml
@@ -13,4 +13,4 @@ sources:
 - https://github.com/cert-manager/csi-driver
 
 appVersion: v0.1.1
-version: v0.1.1
+version: v0.1.2

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -1,6 +1,6 @@
 # cert-manager-csi-driver
 
-![Version: v0.1.1](https://img.shields.io/badge/Version-v0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1](https://img.shields.io/badge/AppVersion-v0.1.1-informational?style=flat-square)
+![Version: v0.1.2](https://img.shields.io/badge/Version-v0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1](https://img.shields.io/badge/AppVersion-v0.1.1-informational?style=flat-square)
 
 A Helm chart for cert-manager-csi-driver
 
@@ -31,3 +31,4 @@ A Helm chart for cert-manager-csi-driver
 | nodeDriverRegistrarImage.repository | string | `"k8s.gcr.io/sig-storage/csi-node-driver-registrar"` | Target image repository. |
 | nodeDriverRegistrarImage.tag | string | `"v2.3.0"` | Target image version tag. |
 | resources | object | `{}` |  |
+


### PR DESCRIPTION
Bumped version after #63 

After this merges, we can release a new helm chart version.

/assign @irbekrm @jakexks 
/cc @MattiasGees 

```release-note
NONE
```