### PR TITLE
Add digest to HELM chart

### DIFF
--- a/deploy/charts/csi-driver/Chart.yaml
+++ b/deploy/charts/csi-driver/Chart.yaml
@@ -13,4 +13,4 @@ sources:
 - https://github.com/cert-manager/csi-driver
 
 appVersion: v0.5.0
-version: v0.5.0
+version: v0.5.1

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -1,6 +1,6 @@
 # cert-manager-csi-driver
 
-![Version: v0.5.0](https://img.shields.io/badge/Version-v0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0](https://img.shields.io/badge/AppVersion-v0.5.0-informational?style=flat-square)
+![Version: v0.5.1](https://img.shields.io/badge/Version-v0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0](https://img.shields.io/badge/AppVersion-v0.5.0-informational?style=flat-square)
 
 A Helm chart for cert-manager-csi-driver
 

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
 
         - name: node-driver-registrar
-          image: "{{ .Values.nodeDriverRegistrarImage.repository }}{{- if (.Values.nodeDriverRegistrarImage.digest) -}} @{{.Values.nodeDriverRegistrarImage.digest}}{{- else -}}:{{ default  .Values.nodeDriverRegistrarImage.tag }} {{- end -}}"
+          image: "{{ .Values.nodeDriverRegistrarImage.repository }}{{- if (.Values.nodeDriverRegistrarImage.digest) -}} @{{.Values.nodeDriverRegistrarImage.digest}}{{- else -}}:{{ default $.Chart.AppVersion .Values.nodeDriverRegistrarImage.tag }} {{- end -}}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - -v={{ .Values.app.logLevel }}
@@ -56,8 +56,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          image: "{{ .Values.image.repository }}{{- if (.Values.image.digest) -}} @{{.Values.image.digest}}{{- else -}}:{{ default  .Values.image.tag }} {{- end -}}"
+          image: "{{ .Values.image.repository }}{{- if (.Values.image.digest) -}} @{{.Values.image.digest}}{{- else -}}:{{ default $.Chart.AppVersion .Values.image.tag }} {{- end -}}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args :
             - --log-level={{ .Values.app.logLevel }}

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
 
         - name: node-driver-registrar
-          image: "{{ .Values.nodeDriverRegistrarImage.repository }}:{{ .Values.nodeDriverRegistrarImage.tag }}"
+          image: "{{ .Values.nodeDriverRegistrarImage.repository }}{{- if (.Values.nodeDriverRegistrarImage.digest) -}} @{{.Values.nodeDriverRegistrarImage.digest}}{{- else -}}:{{ default  .Values.nodeDriverRegistrarImage.tag }} {{- end -}}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - -v={{ .Values.app.logLevel }}
@@ -57,6 +57,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}{{- if (.Values.image.digest) -}} @{{.Values.image.digest}}{{- else -}}:{{ default  .Values.image.tag }} {{- end -}}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args :
             - --log-level={{ .Values.app.logLevel }}

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -6,7 +6,7 @@ image:
   # -- Kubernetes imagePullPolicy on csi-driver.
   pullPolicy: IfNotPresent
   # Setting a digest will override any tag
-  # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+  # digest: sha256:xxxx
 
 # -- Optional secrets used for pulling the csi-driver container image
 imagePullSecrets: []
@@ -28,7 +28,7 @@ livenessProbeImage:
   # -- Kubernetes imagePullPolicy on liveness probe.
   pullPolicy: IfNotPresent
   # Setting a digest will override any tag
-  # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+  # digest: sha256:xxxx
 
 app:
   # -- Verbosity of cert-manager-csi-driver logging.

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -5,6 +5,8 @@ image:
   tag: v0.5.0
   # -- Kubernetes imagePullPolicy on csi-driver.
   pullPolicy: IfNotPresent
+  # Setting a digest will override any tag
+  # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
 
 # -- Optional secrets used for pulling the csi-driver container image
 imagePullSecrets: []
@@ -25,6 +27,8 @@ livenessProbeImage:
   tag: v2.6.0
   # -- Kubernetes imagePullPolicy on liveness probe.
   pullPolicy: IfNotPresent
+  # Setting a digest will override any tag
+  # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
 
 app:
   # -- Verbosity of cert-manager-csi-driver logging.


### PR DESCRIPTION
In some cases, you want to use the specific sha256 digest of an image instead of a tag.

I tested this on my local setup with and without digest.
