### PR TITLE
Move csi-data-dir configuration into values.yaml.

### DIFF
--- a/deploy/charts/csi-driver/Chart.yaml
+++ b/deploy/charts/csi-driver/Chart.yaml
@@ -13,4 +13,4 @@ sources:
 - https://github.com/cert-manager/csi-driver
 
 appVersion: v0.2.0
-version: v0.2.0
+version: v0.2.1

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -1,6 +1,6 @@
 # cert-manager-csi-driver
 
-![Version: v0.2.0](https://img.shields.io/badge/Version-v0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: v0.2.1](https://img.shields.io/badge/Version-v0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for cert-manager-csi-driver
 
@@ -20,7 +20,8 @@ A Helm chart for cert-manager-csi-driver
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| app.driver | object | `{"name":"csi.cert-manager.io","useTokenRequest":false}` | Options for CSI driver |
+| app.driver | object | `{"csiDataDir":"/tmp/cert-manager-csi-driver","name":"csi.cert-manager.io","useTokenRequest":false}` | Options for CSI driver |
+| app.driver.csiDataDir | string | `"/tmp/cert-manager-csi-driver"` | Configures the hostPath directory that the driver will write and mount volumes from. |
 | app.driver.name | string | `"csi.cert-manager.io"` | Name of the driver which will be registered with Kubernetes. |
 | app.driver.useTokenRequest | bool | `false` | If enabled, will use CSI token request for creating CertificateRequests. CertificateRequests will be created via mounting pod's service accounts. |
 | app.livenessProbe | object | `{"port":9809}` | Options for the liveness container. |

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -109,6 +109,6 @@ spec:
             type: Directory
           name: registration-dir
         - hostPath:
-            path: /tmp/cert-manager-csi-driver
+            path: {{ .Values.app.driver.csiDataDir }}
             type: DirectoryOrCreate
           name: csi-data-dir

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -33,11 +33,12 @@ app:
     # CertificateRequests. CertificateRequests will be created via mounting
     # pod's service accounts.
     useTokenRequest: false
+    # -- Configures the hostPath directory that the driver will write and mount volumes from.
+    csiDataDir: /tmp/cert-manager-csi-driver
   # -- Options for the liveness container.
   livenessProbe:
     # -- The port that will expose the livness of the csi-driver
     port: 9809
-
 
 resources: {}
   # -- Kubernetes pod resource limits for cert-manager-csi-driver


### PR DESCRIPTION
This allows a different hostPath to be used, working around an issue with system-tmpfiles-clean task.

Resolves https://github.com/cert-manager/csi-lib/issues/18