### PR TITLE
Remove disable-auto-renew from example Deployment

### DIFF
--- a/deploy/example/example-app.yaml
+++ b/deploy/example/example-app.yaml
@@ -67,4 +67,3 @@ spec:
                   csi.cert-manager.io/issuer-name: ca-issuer
                   csi.cert-manager.io/dns-names: my-service.sandbox.svc.cluster.local
                   csi.cert-manager.io/uri-sans: spiffe://my-service.sandbox.cluster.local
-                  csi.cert-manager.io/disable-auto-renew: "true"


### PR DESCRIPTION
It doesn't make much sense including this in the example, and will lead to people copy and pasting it and having a bad experience.