### PR TITLE
Update maintainers to point at team email

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+.DEFAULT_GOAL := help
+
 BINDIR ?= $(CURDIR)/bin
 ARCH   ?= $(shell go env GOARCH)
 HELM_VERSION ?= 3.4.1
@@ -25,25 +27,29 @@ ifeq ($(UNAME_S),Darwin)
 	OS := darwin
 endif
 
+.PHONY: help
 help:  ## display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-.PHONY: help build docker_build test depend verify all clean generate
+.PHONY: all
+all: verify build image chart-readme  ## runs test, build and image build
 
-all: verify build image ## runs test, build and image build
-
+.PHONY: clean
 clean: ## clean all bin data
 	rm -rf ./bin
 
-build: ## build cert-manager-csi-driver
-	mkdir -p $(BINDIR)
-	GO111MODULE=on CGO_ENABLED=0 go build -v -o ./bin/cert-manager-csi-driver ./cmd/.
+.PHONY: build
+build:  | $(BINDIR) ## build cert-manager-csi-driver
+	GO111MODULE=on CGO_ENABLED=0 go build -v -o $(BINDIR)/cert-manager-csi-driver ./cmd/.
 
+.PHONY: verify
 verify: test boilerplate ## verify codebase
 
+.PHONY: test
 test: ## offline test cert-manager-csi-driver
 	go test -v ./pkg/...
 
+.PHONY: boilerplate
 boilerplate: ## verify boilerplate headers
 	./hack/verify-boilerplate.sh
 
@@ -54,14 +60,31 @@ boilerplate: ## verify boilerplate headers
 image: ## build cert-manager-csi-driver docker image targeting all supported platforms
 	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/cert-manager-csi-driver:v0.3.0 --output type=oci,dest=./bin/cert-manager-csi-driver-oci .
 
+.PHONY: e2e
 e2e: depend ## run end to end tests
 	./test/run.sh
 
-depend: $(BINDIR)/helm
+CHART_YAML := $(shell find deploy/charts/csi-driver -name "*.yaml")
 
-$(BINDIR)/helm:
-	mkdir -p $(BINDIR)
+.PHONY: chart-readme
+chart-readme: deploy/charts/csi-driver/README.md  ## update helm chart README file
+
+deploy/charts/csi-driver/README.md: $(BINDIR)/helm-docs $(CHART_YAML)
+	$(BINDIR)/helm-docs
+
+.PHONY: depend
+depend: $(BINDIR)/helm $(BINDIR)/helm-docs
+
+$(BINDIR)/helm: | $(BINDIR)
 	curl -o $(BINDIR)/helm.tar.gz -LO "https://get.helm.sh/helm-v$(HELM_VERSION)-$(OS)-$(ARCH).tar.gz"
 	tar -C $(BINDIR) -xzf $(BINDIR)/helm.tar.gz
 	cp $(BINDIR)/$(OS)-$(ARCH)/helm $(BINDIR)/helm
 	rm -r $(BINDIR)/$(OS)-$(ARCH) $(BINDIR)/helm.tar.gz
+
+HELM_DOCS_VERSION=1.10.0
+
+$(BINDIR)/helm-docs: | $(BINDIR)
+	GOBIN=$(BINDIR) go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.10.0
+
+$(BINDIR):
+	mkdir -p $@

--- a/deploy/charts/csi-driver/Chart.yaml
+++ b/deploy/charts/csi-driver/Chart.yaml
@@ -6,8 +6,8 @@ description: A Helm chart for cert-manager-csi-driver
 
 home: https://github.com/cert-manager/csi-driver
 maintainers:
-- name: joshvanl
-  email: joshua.vanleeuwen@jetstack.io
+- name: cert-manager-maintainers
+  email: cert-manager-maintainers@googlegroups.com
   url: https://cert-manager.io
 sources:
 - https://github.com/cert-manager/csi-driver

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -10,7 +10,7 @@ A Helm chart for cert-manager-csi-driver
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| joshvanl | joshua.vanleeuwen@jetstack.io | https://cert-manager.io |
+| cert-manager-maintainers | <cert-manager-maintainers@googlegroups.com> | <https://cert-manager.io> |
 
 ## Source Code
 


### PR DESCRIPTION
Spotted while reviewing deployment of chart for v0.3.0! I don't think there any reason for the `maintainers` field to vary in any chart in the cert-manager org.