### PR TITLE
PKCS12 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY go.sum go.sum
 COPY Makefile Makefile
 COPY cmd/ cmd/
 COPY pkg/ pkg/
+COPY internal/ internal/
 
 # Build
 RUN make build

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/kubectl v0.23.6
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.11.2
+	software.sslmate.com/src/go-pkcs12 v0.0.0-20210415151418-c5206de65a78
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1336,3 +1336,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
+software.sslmate.com/src/go-pkcs12 v0.0.0-20210415151418-c5206de65a78 h1:SqYE5+A2qvRhErbsXFfUEUmpWEKxxRSMgGLkvRAFOV4=
+software.sslmate.com/src/go-pkcs12 v0.0.0-20210415151418-c5206de65a78/go.mod h1:B7Wf0Ya4DHF9Yw+qfZuJijQYkWicqDa+79Ytmmq3Kjg=

--- a/internal/pkg/keystore/pkcs12/pkcs12.go
+++ b/internal/pkg/keystore/pkcs12/pkcs12.go
@@ -34,11 +34,11 @@ func Create(key crypto.PrivateKey, chainPEM []byte, rootPEM []byte) ([]byte, err
 	}
 
 	if len(chainPEM) == 0 {
-		return nil, errors.New("chain must not be empty")
+		return nil, errors.New("chainPEM must not be empty")
 	}
 
 	if len(rootPEM) == 0 {
-		return nil, errors.New("root must not be empty")
+		return nil, errors.New("rootPEM must not be empty")
 	}
 
 	root, err := pki.DecodeX509CertificateBytes(rootPEM)

--- a/internal/pkg/keystore/pkcs12/pkcs12.go
+++ b/internal/pkg/keystore/pkcs12/pkcs12.go
@@ -41,26 +41,23 @@ func Create(key crypto.PrivateKey, chainPEM []byte, rootPEM []byte) ([]byte, err
 		return nil, errors.New("root must not be empty")
 	}
 
-	rc, err := pki.DecodeX509CertificateBytes(rootPEM)
+	root, err := pki.DecodeX509CertificateBytes(rootPEM)
 	if err != nil {
 		return nil, fmt.Errorf("pki.DecodeX509CertificateChainBytes(rootPEM): %v", err)
 	}
 
-	cc, err := pki.DecodeX509CertificateChainBytes(chainPEM)
+	chain, err := pki.DecodeX509CertificateChainBytes(chainPEM)
 	if err != nil {
 		return nil, fmt.Errorf("pki.DecodeX509CertificateChainBytes(chainPEM): %v", err)
 	}
 
-	// we need to grab the leaf cert from chain
-	// TODO: is it the first cert or the last?
-	// leaf is the last cert - right?
-	leaf := cc[len(cc)-1]
-	cc = cc[:len(cc)-1]
+	leaf := chain[0]
+	chain = chain[1:]
 
 	// add the root cert to the back of the chain
-	cc = append(cc, rc)
+	chain = append(chain, root)
 
-	pfx, err := pkcs12.Encode(rand.Reader, key, leaf, cc, pkcs12.DefaultPassword)
+	pfx, err := pkcs12.Encode(rand.Reader, key, leaf, chain, pkcs12.DefaultPassword)
 	if err != nil {
 		return nil, fmt.Errorf("pkcs12.Encode: %v", err)
 	}

--- a/internal/pkg/keystore/pkcs12/pkcs12.go
+++ b/internal/pkg/keystore/pkcs12/pkcs12.go
@@ -1,0 +1,34 @@
+package pkcs12
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"fmt"
+
+	"github.com/cert-manager/cert-manager/pkg/util/pki"
+	"software.sslmate.com/src/go-pkcs12"
+)
+
+// Create combines the inputs to a single pfx/p12 file
+func Create(key crypto.PrivateKey, leaf []byte, chain []byte) ([]byte, error) {
+	cert, err := pki.DecodeX509CertificateBytes(leaf)
+	if err != nil {
+		return nil, fmt.Errorf("pki.DecodeX509CertificateChainBytes(leaf): %v", err)
+	}
+
+	var cas []*x509.Certificate
+	if len(chain) > 0 {
+		cas, err = pki.DecodeX509CertificateChainBytes(chain)
+		if err != nil {
+			return nil, fmt.Errorf("pki.DecodeX509CertificateChainBytes(chain): %v", err)
+		}
+	}
+
+	pfx, err := pkcs12.Encode(rand.Reader, key, cert, cas, pkcs12.DefaultPassword)
+	if err != nil {
+		return nil, fmt.Errorf("pkcs12.Encode: %v", err)
+	}
+
+	return pfx, nil
+}

--- a/internal/pkg/keystore/pkcs12/pkcs12.go
+++ b/internal/pkg/keystore/pkcs12/pkcs12.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package pkcs12
 
 import (

--- a/internal/pkg/keystore/pkcs12/pkcs12.go
+++ b/internal/pkg/keystore/pkcs12/pkcs12.go
@@ -26,6 +26,8 @@ import (
 	"software.sslmate.com/src/go-pkcs12"
 )
 
+// TODO: other parts of this codebase reasons about the chain as cert + intermediate, and root separately
+//		 do we also want to do that in this signature? doesn't make sense for pkcs12
 // Create combines the inputs to a single pfx/p12 file
 func Create(key crypto.PrivateKey, leaf []byte, chain []byte) ([]byte, error) {
 	cert, err := pki.DecodeX509CertificateBytes(leaf)

--- a/internal/pkg/keystore/pkcs12/pkcs12_test.go
+++ b/internal/pkg/keystore/pkcs12/pkcs12_test.go
@@ -62,47 +62,47 @@ func generateKeyAndCert(t *testing.T) (*rsa.PrivateKey, *x509.Certificate, []byt
 		IsCA:                  true,
 	}
 
-	db, err := x509.CreateCertificate(rand.Reader, &template, &template, &pk.PublicKey, pk)
+	leafDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &pk.PublicKey, pk)
 	if err != nil {
-		t.Fatalf("x509.CreateCertificate: %v", err)
+		t.Fatalf("x509.CreateCertificate(leaf): %v", err)
 	}
 
-	leaf, err := x509.ParseCertificate(db)
+	leaf, err := x509.ParseCertificate(leafDER)
 	if err != nil {
-		t.Fatalf("x509.ParseCertificate: %v", err)
+		t.Fatalf("x509.ParseCertificate(leafDER): %v", err)
 	}
 
-	idb, err := x509.CreateCertificate(rand.Reader, &intermediateTemplate, &intermediateTemplate, &pk.PublicKey, pk)
+	intermediateDER, err := x509.CreateCertificate(rand.Reader, &intermediateTemplate, &intermediateTemplate, &pk.PublicKey, pk)
 	if err != nil {
 		t.Fatalf("x509.CreateCertificate(intermediate): %v", err)
 	}
 
-	ic, err := x509.ParseCertificate(idb)
+	intermediate, err := x509.ParseCertificate(intermediateDER)
 	if err != nil {
-		t.Errorf("x509.ParseCertificate(idb): %v", err)
+		t.Errorf("x509.ParseCertificate(intermediateDER): %v", err)
 	}
 
 	rootDER, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &pk.PublicKey, pk)
 	if err != nil {
-		t.Fatalf("x509.CreateCertificate(ca): %v", err)
+		t.Fatalf("x509.CreateCertificate(root): %v", err)
 	}
 
 	root, err := x509.ParseCertificate(rootDER)
 	if err != nil {
-		t.Fatalf("x509.ParseCertificate: %v", err)
+		t.Fatalf("x509.ParseCertificate(rootDER): %v", err)
 	}
 
-	caChain := []*x509.Certificate{ic, root}
-	chainDER := append(db, idb...)
+	caChain := []*x509.Certificate{intermediate, root}
+	chainDER := append(leafDER, intermediateDER...)
 
 	chain, err := x509.ParseCertificates(chainDER)
 	if err != nil {
 		t.Fatalf("x509.ParseCertificates(chainDER): %v", err)
 	}
 
-	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: db})
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
+	intermediatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: intermediateDER})
 	rootPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER})
-	intermediatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: idb})
 
 	chainPEM := append(leafPEM, intermediatePEM...)
 

--- a/internal/pkg/keystore/pkcs12/pkcs12_test.go
+++ b/internal/pkg/keystore/pkcs12/pkcs12_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package pkcs12
 
 import (

--- a/internal/pkg/keystore/pkcs12/pkcs12_test.go
+++ b/internal/pkg/keystore/pkcs12/pkcs12_test.go
@@ -1,0 +1,133 @@
+package pkcs12
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"software.sslmate.com/src/go-pkcs12"
+)
+
+var (
+	notBefore = time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+	notAfter  = time.Date(1970, time.January, 4, 0, 0, 0, 0, time.UTC)
+)
+
+func generateKeyAndCert(t *testing.T) (*rsa.PrivateKey, []byte, []byte) {
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber:          new(big.Int).Lsh(big.NewInt(1), 128),
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		BasicConstraintsValid: true,
+	}
+
+	intermediateTemplate := x509.Certificate{
+		SerialNumber:          new(big.Int).Lsh(big.NewInt(1), 128),
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		BasicConstraintsValid: true,
+	}
+
+	caTemplate := x509.Certificate{
+		SerialNumber:          new(big.Int).Lsh(big.NewInt(1), 128),
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	db, err := x509.CreateCertificate(rand.Reader, &template, &template, &pk.PublicKey, pk)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate: %v", err)
+	}
+
+	//cert, err := x509.ParseCertificate(db)
+	//if err != nil {
+	//	t.Fatalf("x509.ParseCertificate: %v", err)
+	//}
+
+	idb, err := x509.CreateCertificate(rand.Reader, &intermediateTemplate, &intermediateTemplate, &pk.PublicKey, pk)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate(intermediate): %v", err)
+	}
+
+	rdb, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &pk.PublicKey, pk)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate(ca): %v", err)
+	}
+
+	// TODO: can we use the concatenated PEM chain?
+	_ = append(idb, rdb...)
+
+	//var blocks []*pem.Block
+	//for {
+	//	b, rest := pem.Decode(cdb)
+	//
+	//	blocks = append(blocks, b)
+	//
+	//	if len(rest) == 0 {
+	//		break
+	//	}
+	//}
+
+	//chain, err := x509.ParseCertificates(cb)
+	//if err != nil {
+	//	t.Fatalf("x509.ParseCertificates: %v", err)
+	//}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: db})
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rdb})
+
+	//return pk, db, cb
+	return pk, certPEM, caPEM
+}
+
+func TestCreate(t *testing.T) {
+	key, leaf, chain := generateKeyAndCert(t)
+	tests := map[string]struct {
+		key    *rsa.PrivateKey
+		leaf   []byte
+		chain  []byte
+		expErr bool
+	}{
+		"happy path": {
+			key:    key,
+			leaf:   leaf,
+			chain:  chain,
+			expErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			p12, err := Create(test.key, test.leaf, test.chain)
+
+			if test.expErr {
+				assert.Error(t, err)
+				return
+			} else {
+				assert.NoError(t, err)
+			}
+
+			pk, cert, ca, err := pkcs12.DecodeChain(p12, pkcs12.DefaultPassword)
+			assert.NoError(t, err)
+			assert.NotNil(t, pk)
+			assert.NotNil(t, cert)
+			assert.NotNil(t, ca)
+
+			//assert.Equal(t, test.key, pk.(*rsa.PrivateKey))
+			//assert.Equal(t, test.cert, cert)
+			//assert.Equal(t, []*x509.Certificate{test.testBundle.ca}, ca)
+		})
+	}
+}

--- a/internal/pkg/keystore/pkcs12/pkcs12_test.go
+++ b/internal/pkg/keystore/pkcs12/pkcs12_test.go
@@ -122,7 +122,7 @@ func TestCreate(t *testing.T) {
 		caChain  []*x509.Certificate
 		expErr   bool
 	}{
-		"happy path": {
+		"happy path, with intermediate": {
 			key:      key,
 			leaf:     leaf,
 			leafPEM:  leafPEM,
@@ -133,7 +133,7 @@ func TestCreate(t *testing.T) {
 			caChain:  caChain,
 			expErr:   false,
 		},
-		"without intermediate succeeds": {
+		"happy path, without intermediate": {
 			key:      key,
 			leaf:     leaf,
 			chainPEM: leafPEM,

--- a/pkg/apis/defaults/defaults.go
+++ b/pkg/apis/defaults/defaults.go
@@ -44,7 +44,7 @@ func SetDefaultAttributes(attrOriginal map[string]string) (map[string]string, er
 	setDefaultIfEmpty(attr, csiapi.KeyFileKey, "tls.key")
 
 	setDefaultIfEmpty(attr, csiapi.KeyEncodingKey, "PKCS1")
-	setDefaultIfEmpty(attr, csiapi.KeystoreType, "PKCS12")
+	setDefaultIfEmpty(attr, csiapi.KeystoreTypeKey, "PKCS12")
 
 	setDefaultIfEmpty(attr, csiapi.KeyUsagesKey, strings.Join([]string{string(cmapi.UsageDigitalSignature), string(cmapi.UsageKeyEncipherment)}, ","))
 

--- a/pkg/apis/defaults/defaults.go
+++ b/pkg/apis/defaults/defaults.go
@@ -44,6 +44,7 @@ func SetDefaultAttributes(attrOriginal map[string]string) (map[string]string, er
 	setDefaultIfEmpty(attr, csiapi.KeyFileKey, "tls.key")
 
 	setDefaultIfEmpty(attr, csiapi.KeyEncodingKey, "PKCS1")
+	setDefaultIfEmpty(attr, csiapi.KeystoreType, "PKCS12")
 
 	setDefaultIfEmpty(attr, csiapi.KeyUsagesKey, strings.Join([]string{string(cmapi.UsageDigitalSignature), string(cmapi.UsageKeyEncipherment)}, ","))
 

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -38,8 +38,8 @@ const (
 	RenewBeforeKey  = "csi.cert-manager.io/renew-before"
 	ReusePrivateKey = "csi.cert-manager.io/reuse-private-key"
 
-	KeystoreType = "csi.cert-manager.io/keystore-type"
-	KeystoreFile = "csi.cert-manager.io/keystore-file"
+	KeystoreTypeKey = "csi.cert-manager.io/keystore-type"
+	KeystoreFileKey = "csi.cert-manager.io/keystore-file"
 )
 
 const (

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -37,6 +37,9 @@ const (
 
 	RenewBeforeKey  = "csi.cert-manager.io/renew-before"
 	ReusePrivateKey = "csi.cert-manager.io/reuse-private-key"
+
+	KeystoreType = "csi.cert-manager.io/keystore-type"
+	KeystoreFile = "csi.cert-manager.io/keystore-file"
 )
 
 const (

--- a/pkg/apis/validation/validation.go
+++ b/pkg/apis/validation/validation.go
@@ -52,7 +52,7 @@ func ValidateAttributes(attr map[string]string) field.ErrorList {
 
 	el = append(el, keyEncodingValue(path.Child(csiapi.KeyEncodingKey), attr[csiapi.KeyEncodingKey])...)
 
-	el = append(el, keystoreTypeValue(path.Child(csiapi.KeystoreType), attr[csiapi.KeystoreType])...)
+	el = append(el, keystoreTypeValue(path.Child(csiapi.KeystoreTypeKey), attr[csiapi.KeystoreTypeKey])...)
 
 	// If there are errors, then return not approved and the aggregated errors.
 	if len(el) > 0 {

--- a/pkg/apis/validation/validation.go
+++ b/pkg/apis/validation/validation.go
@@ -52,6 +52,8 @@ func ValidateAttributes(attr map[string]string) field.ErrorList {
 
 	el = append(el, keyEncodingValue(path.Child(csiapi.KeyEncodingKey), attr[csiapi.KeyEncodingKey])...)
 
+	el = append(el, keystoreTypeValue(path.Child(csiapi.KeystoreType), attr[csiapi.KeystoreType])...)
+
 	// If there are errors, then return not approved and the aggregated errors.
 	if len(el) > 0 {
 		return el
@@ -108,8 +110,16 @@ func boolValue(path *field.Path, s string) field.ErrorList {
 }
 
 func keyEncodingValue(path *field.Path, s string) field.ErrorList {
-	if s != string(cmapi.PKCS1) && s != string(cmapi.PKCS8) && s != "PKCS12" {
+	if s != string(cmapi.PKCS1) && s != string(cmapi.PKCS8) {
 		return field.ErrorList{field.NotSupported(path, s, []string{string(cmapi.PKCS1), string(cmapi.PKCS8)})}
 	}
+	return nil
+}
+
+func keystoreTypeValue(path *field.Path, s string) field.ErrorList {
+	if s != "PKCS12" {
+		return field.ErrorList{field.NotSupported(path, s, []string{"PKCS12"})}
+	}
+
 	return nil
 }

--- a/pkg/apis/validation/validation.go
+++ b/pkg/apis/validation/validation.go
@@ -108,7 +108,7 @@ func boolValue(path *field.Path, s string) field.ErrorList {
 }
 
 func keyEncodingValue(path *field.Path, s string) field.ErrorList {
-	if s != string(cmapi.PKCS1) && s != string(cmapi.PKCS8) {
+	if s != string(cmapi.PKCS1) && s != string(cmapi.PKCS8) && s != "PKCS12" {
 		return field.ErrorList{field.NotSupported(path, s, []string{string(cmapi.PKCS1), string(cmapi.PKCS8)})}
 	}
 	return nil

--- a/pkg/apis/validation/validation_test.go
+++ b/pkg/apis/validation/validation_test.go
@@ -40,6 +40,7 @@ func Test_ValidateAttributes(t *testing.T) {
 			attr: map[string]string{
 				csiapi.DNSNamesKey:    "foo.bar.com,car.bar.com",
 				csiapi.KeyEncodingKey: "PKCS1",
+				csiapi.KeystoreType:   "PKCS12",
 			},
 			expErr: field.ErrorList{
 				field.Required(field.NewPath("volumeAttributes", "csi.cert-manager.io/issuer-name"), "issuer-name is a required field"),
@@ -49,6 +50,7 @@ func Test_ValidateAttributes(t *testing.T) {
 			attr: map[string]string{
 				csiapi.CommonNameKey:  "foo.bar",
 				csiapi.KeyEncodingKey: "PKCS1",
+				csiapi.KeystoreType:   "PKCS12",
 			},
 			expErr: field.ErrorList{
 				field.Required(field.NewPath("volumeAttributes", "csi.cert-manager.io/issuer-name"), "issuer-name is a required field"),
@@ -59,6 +61,7 @@ func Test_ValidateAttributes(t *testing.T) {
 				csiapi.IssuerNameKey:  "test-issuer",
 				csiapi.CommonNameKey:  "foo.bar",
 				csiapi.KeyEncodingKey: "PKCS1",
+				csiapi.KeystoreType:   "PKCS12",
 			},
 			expErr: nil,
 		},
@@ -67,6 +70,7 @@ func Test_ValidateAttributes(t *testing.T) {
 				csiapi.IssuerNameKey:  "test-issuer",
 				csiapi.DNSNamesKey:    "foo.bar.com,car.bar.com",
 				csiapi.KeyEncodingKey: "PKCS1",
+				csiapi.KeystoreType:   "PKCS12",
 			},
 			expErr: nil,
 		},
@@ -76,6 +80,7 @@ func Test_ValidateAttributes(t *testing.T) {
 				csiapi.DNSNamesKey:    "foo.bar.com,car.bar.com",
 				csiapi.KeyUsagesKey:   "client auth",
 				csiapi.KeyEncodingKey: "PKCS1",
+				csiapi.KeystoreType:   "PKCS12",
 			},
 			expErr: nil,
 		},
@@ -85,6 +90,7 @@ func Test_ValidateAttributes(t *testing.T) {
 				csiapi.DNSNamesKey:    "foo.bar.com,car.bar.com",
 				csiapi.KeyUsagesKey:   "code signing  ,      email protection,    s/mime,ipsec end system",
 				csiapi.KeyEncodingKey: "PKCS1",
+				csiapi.KeystoreType:   "PKCS12",
 			},
 			expErr: nil,
 		},
@@ -94,6 +100,7 @@ func Test_ValidateAttributes(t *testing.T) {
 				csiapi.DNSNamesKey:    "foo.bar.com,car.bar.com",
 				csiapi.KeyUsagesKey:   "foo,bar,hello world",
 				csiapi.KeyEncodingKey: "PKCS1",
+				csiapi.KeystoreType:   "PKCS12",
 			},
 			expErr: field.ErrorList{
 				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/key-usages"), "foo", "not a valid key usage"),
@@ -107,6 +114,7 @@ func Test_ValidateAttributes(t *testing.T) {
 				csiapi.DurationKey:     "bad-duration",
 				csiapi.ReusePrivateKey: "FOO",
 				csiapi.KeyEncodingKey:  "PKCS1",
+				csiapi.KeystoreType:    "PKCS12",
 			},
 			expErr: field.ErrorList{
 				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/duration"), "bad-duration", `must be a valid duration string: time: invalid duration "bad-duration"`),

--- a/pkg/apis/validation/validation_test.go
+++ b/pkg/apis/validation/validation_test.go
@@ -38,9 +38,9 @@ func Test_ValidateAttributes(t *testing.T) {
 	}{
 		"attributes with no issuer name but DNS names should error": {
 			attr: map[string]string{
-				csiapi.DNSNamesKey:    "foo.bar.com,car.bar.com",
-				csiapi.KeyEncodingKey: "PKCS1",
-				csiapi.KeystoreType:   "PKCS12",
+				csiapi.DNSNamesKey:     "foo.bar.com,car.bar.com",
+				csiapi.KeyEncodingKey:  "PKCS1",
+				csiapi.KeystoreTypeKey: "PKCS12",
 			},
 			expErr: field.ErrorList{
 				field.Required(field.NewPath("volumeAttributes", "csi.cert-manager.io/issuer-name"), "issuer-name is a required field"),
@@ -48,9 +48,9 @@ func Test_ValidateAttributes(t *testing.T) {
 		},
 		"attributes with common name but no issuer name or DNS names should error": {
 			attr: map[string]string{
-				csiapi.CommonNameKey:  "foo.bar",
-				csiapi.KeyEncodingKey: "PKCS1",
-				csiapi.KeystoreType:   "PKCS12",
+				csiapi.CommonNameKey:   "foo.bar",
+				csiapi.KeyEncodingKey:  "PKCS1",
+				csiapi.KeystoreTypeKey: "PKCS12",
 			},
 			expErr: field.ErrorList{
 				field.Required(field.NewPath("volumeAttributes", "csi.cert-manager.io/issuer-name"), "issuer-name is a required field"),
@@ -58,49 +58,49 @@ func Test_ValidateAttributes(t *testing.T) {
 		},
 		"valid attributes with common name should return no error": {
 			attr: map[string]string{
-				csiapi.IssuerNameKey:  "test-issuer",
-				csiapi.CommonNameKey:  "foo.bar",
-				csiapi.KeyEncodingKey: "PKCS1",
-				csiapi.KeystoreType:   "PKCS12",
+				csiapi.IssuerNameKey:   "test-issuer",
+				csiapi.CommonNameKey:   "foo.bar",
+				csiapi.KeyEncodingKey:  "PKCS1",
+				csiapi.KeystoreTypeKey: "PKCS12",
 			},
 			expErr: nil,
 		},
 		"valid attributes with DNS names should return no error": {
 			attr: map[string]string{
-				csiapi.IssuerNameKey:  "test-issuer",
-				csiapi.DNSNamesKey:    "foo.bar.com,car.bar.com",
-				csiapi.KeyEncodingKey: "PKCS1",
-				csiapi.KeystoreType:   "PKCS12",
+				csiapi.IssuerNameKey:   "test-issuer",
+				csiapi.DNSNamesKey:     "foo.bar.com,car.bar.com",
+				csiapi.KeyEncodingKey:  "PKCS1",
+				csiapi.KeystoreTypeKey: "PKCS12",
 			},
 			expErr: nil,
 		},
 		"valid attributes with one key usages should return no error": {
 			attr: map[string]string{
-				csiapi.IssuerNameKey:  "test-issuer",
-				csiapi.DNSNamesKey:    "foo.bar.com,car.bar.com",
-				csiapi.KeyUsagesKey:   "client auth",
-				csiapi.KeyEncodingKey: "PKCS1",
-				csiapi.KeystoreType:   "PKCS12",
+				csiapi.IssuerNameKey:   "test-issuer",
+				csiapi.DNSNamesKey:     "foo.bar.com,car.bar.com",
+				csiapi.KeyUsagesKey:    "client auth",
+				csiapi.KeyEncodingKey:  "PKCS1",
+				csiapi.KeystoreTypeKey: "PKCS12",
 			},
 			expErr: nil,
 		},
 		"valid attributes with key usages extended key usages should return no error": {
 			attr: map[string]string{
-				csiapi.IssuerNameKey:  "test-issuer",
-				csiapi.DNSNamesKey:    "foo.bar.com,car.bar.com",
-				csiapi.KeyUsagesKey:   "code signing  ,      email protection,    s/mime,ipsec end system",
-				csiapi.KeyEncodingKey: "PKCS1",
-				csiapi.KeystoreType:   "PKCS12",
+				csiapi.IssuerNameKey:   "test-issuer",
+				csiapi.DNSNamesKey:     "foo.bar.com,car.bar.com",
+				csiapi.KeyUsagesKey:    "code signing  ,      email protection,    s/mime,ipsec end system",
+				csiapi.KeyEncodingKey:  "PKCS1",
+				csiapi.KeystoreTypeKey: "PKCS12",
 			},
 			expErr: nil,
 		},
 		"attributes with wrong key usages should error": {
 			attr: map[string]string{
-				csiapi.IssuerNameKey:  "test-issuer",
-				csiapi.DNSNamesKey:    "foo.bar.com,car.bar.com",
-				csiapi.KeyUsagesKey:   "foo,bar,hello world",
-				csiapi.KeyEncodingKey: "PKCS1",
-				csiapi.KeystoreType:   "PKCS12",
+				csiapi.IssuerNameKey:   "test-issuer",
+				csiapi.DNSNamesKey:     "foo.bar.com,car.bar.com",
+				csiapi.KeyUsagesKey:    "foo,bar,hello world",
+				csiapi.KeyEncodingKey:  "PKCS1",
+				csiapi.KeystoreTypeKey: "PKCS12",
 			},
 			expErr: field.ErrorList{
 				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/key-usages"), "foo", "not a valid key usage"),
@@ -114,7 +114,7 @@ func Test_ValidateAttributes(t *testing.T) {
 				csiapi.DurationKey:     "bad-duration",
 				csiapi.ReusePrivateKey: "FOO",
 				csiapi.KeyEncodingKey:  "PKCS1",
-				csiapi.KeystoreType:    "PKCS12",
+				csiapi.KeystoreTypeKey: "PKCS12",
 			},
 			expErr: field.ErrorList{
 				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/duration"), "bad-duration", `must be a valid duration string: time: invalid duration "bad-duration"`),

--- a/pkg/filestore/writer.go
+++ b/pkg/filestore/writer.go
@@ -39,44 +39,6 @@ type Writer struct {
 	Store storage.Interface
 }
 
-//
-//// WriteKeystore combines the inputs into a single file of a provided keystore format.
-//func (w *Writer) WriteKeystore(meta metadata.Metadata, key crypto.PrivateKey, chain []byte, ca []byte) error {
-//	certs, err := pki.DecodeX509CertificateChainBytes(chain)
-//	if err != nil {
-//		return fmt.Errorf("pki.DecodeX509CertificateChainBytes(chain): %w", err)
-//	}
-//
-//	var cas []*x509.Certificate
-//	if len(ca) > 0 {
-//		cas, err = pki.DecodeX509CertificateChainBytes(ca)
-//		if err != nil {
-//			return fmt.Errorf("pki.DecodeX509CertificateChainBytes(ca): %w", err)
-//		}
-//	}
-//
-//	// prepend the certificate chain to the list of certificates as the PKCS12
-//	// library only allows setting a single certificate.
-//	if len(certs) > 1 {
-//		cas = append(certs[1:], cas...)
-//	}
-//
-//	pfx, err := pkcs12.Encode(rand.Reader, key, certs[0], cas, pkcs12.DefaultPassword)
-//	if err != nil {
-//		return fmt.Errorf("pkcs12.Encode: %w", err)
-//	}
-//
-//	err = w.Store.WriteFiles(meta, map[string][]byte{
-//		"myp12file": pfx,
-//	})
-//
-//	if err != nil {
-//		return fmt.Errorf("w.Store.WriteFiles: %w", err)
-//	}
-//
-//	return nil
-//}
-
 // WriteKeypair writes the given certificate, CA, and private key data to their
 // respective file locations, according to the volume attributes. Also writes
 // or updates the metadata file, including a calculated NextIssuanceTime.
@@ -107,7 +69,7 @@ func (w *Writer) WriteKeypair(meta metadata.Metadata, key crypto.PrivateKey, cha
 			Type:  "PRIVATE KEY",
 			Bytes: bytes,
 		}
-	case "PKCS12":
+	case "PKCS12": // TODO: use constant from cmapi
 		if attrs[csiapi.KeystoreFile] == "" {
 			return fmt.Errorf("%s must be set", csiapi.KeystoreFile)
 		}
@@ -119,6 +81,7 @@ func (w *Writer) WriteKeypair(meta metadata.Metadata, key crypto.PrivateKey, cha
 			return fmt.Errorf("w.Store.WriteFiles: %v", err)
 		}
 
+		//TODO: de-duplicate issuance code
 		nextIssuanceTime, err := calculateNextIssuanceTime(attrs, chain)
 		if err != nil {
 			return fmt.Errorf("calculating next issuance time: %w", err)

--- a/pkg/filestore/writer.go
+++ b/pkg/filestore/writer.go
@@ -90,8 +90,6 @@ func (w *Writer) WriteKeypair(meta metadata.Metadata, key crypto.PrivateKey, cha
 			}
 
 			files[attrs[csiapi.KeystoreFileKey]] = pfx
-			meta.VolumeContext[csiapi.KeystoreFileKey] = attrs[csiapi.KeystoreFileKey]
-			meta.VolumeContext[csiapi.KeystoreTypeKey] = keyStoreType
 		default:
 			return fmt.Errorf("unsupported keystore-type: %s", keyStoreType)
 		}

--- a/pkg/filestore/writer.go
+++ b/pkg/filestore/writer.go
@@ -81,17 +81,17 @@ func (w *Writer) WriteKeypair(meta metadata.Metadata, key crypto.PrivateKey, cha
 		attrs[csiapi.CAFileKey]:   ca,
 	}
 
-	if attrs[csiapi.KeystoreFile] != "" {
-		switch keyStoreType := attrs[csiapi.KeystoreType]; keyStoreType {
+	if attrs[csiapi.KeystoreFileKey] != "" {
+		switch keyStoreType := attrs[csiapi.KeystoreTypeKey]; keyStoreType {
 		case "PKCS12":
 			pfx, err := pkcs12.Create(key, chain, ca)
 			if err != nil {
 				return fmt.Errorf("pkcs12.Create: %v", err)
 			}
 
-			files[attrs[csiapi.KeystoreFile]] = pfx
-			meta.VolumeContext[csiapi.KeystoreFile] = attrs[csiapi.KeystoreFile]
-			meta.VolumeContext[csiapi.KeystoreType] = keyStoreType
+			files[attrs[csiapi.KeystoreFileKey]] = pfx
+			meta.VolumeContext[csiapi.KeystoreFileKey] = attrs[csiapi.KeystoreFileKey]
+			meta.VolumeContext[csiapi.KeystoreTypeKey] = keyStoreType
 		default:
 			return fmt.Errorf("unsupported keystore-type: %s", keyStoreType)
 		}

--- a/pkg/filestore/writer.go
+++ b/pkg/filestore/writer.go
@@ -98,31 +98,6 @@ func (w *Writer) WriteKeypair(meta metadata.Metadata, key crypto.PrivateKey, cha
 		files = map[string][]byte{
 			attrs[csiapi.KeystoreFile]: pfx,
 		}
-
-		//err = w.Store.WriteFiles(meta, map[string][]byte{
-		//	attrs[csiapi.KeystoreFile]: pfx,
-		//})
-		//if err != nil {
-		//	return fmt.Errorf("w.Store.WriteFiles: %v", err)
-		//}
-
-		//TODO: de-duplicate issuance code
-		//nextIssuanceTime, err := calculateNextIssuanceTime(attrs, chain)
-		//if err != nil {
-		//	return fmt.Errorf("calculating next issuance time: %w", err)
-		//}
-		//
-		//meta.NextIssuanceTime = &nextIssuanceTime
-		//if err := w.Store.WriteMetadata(meta.VolumeID, meta); err != nil {
-		//	klog.Errorf("w.Store.WriteMetadata: %v", err)
-		//	return fmt.Errorf("writing metadata: %w", err)
-		//}
-		//
-		//md, err := w.Store.ReadMetadata(meta.VolumeID)
-		//klog.InfoS("metadata: ", "next issuance", md.NextIssuanceTime)
-		//klog.Info("completed without error for PKCS12", err)
-		//
-		//return nil
 	default:
 		return fmt.Errorf("invalid key encoding format: %s", keyEncodingFormat)
 	}

--- a/pkg/filestore/writer.go
+++ b/pkg/filestore/writer.go
@@ -81,6 +81,8 @@ func (w *Writer) WriteKeypair(meta metadata.Metadata, key crypto.PrivateKey, cha
 		attrs[csiapi.CAFileKey]:   ca,
 	}
 
+	// keystore file is written in _addition_ to PEM files
+	// if not set, continue as usual
 	if attrs[csiapi.KeystoreFileKey] != "" {
 		switch keyStoreType := attrs[csiapi.KeystoreTypeKey]; keyStoreType {
 		case "PKCS12":

--- a/pkg/filestore/writer_test.go
+++ b/pkg/filestore/writer_test.go
@@ -353,7 +353,7 @@ func Test_WriteKeypair(t *testing.T) {
 				"tls.crt": pkcs8Bundle.certPEM,
 				"tls.key": pkcs8Bundle.pkPEM,
 				"metadata.json": []byte(
-					`{"volumeID":"vol-id","targetPath":"/target-path","nextIssuanceTime":"1970-01-03T00:00:00Z","volumeContext":{"csi.cert-manager.io/issuer-name":"ca-issuer","csi.cert-manager.io/key-encoding":"PKCS8","csi.cert-manager.io/keystore-file":"my-file.pfx","csi.cert-manager.io/keystore-type":"PKCS12"}}`,
+					`{"volumeID":"vol-id","targetPath":"/target-path","nextIssuanceTime":"1970-01-03T00:00:00Z","volumeContext":{"csi.cert-manager.io/issuer-name":"ca-issuer","csi.cert-manager.io/key-encoding":"PKCS8","csi.cert-manager.io/keystore-file":"my-file.pfx"}}`,
 				),
 			},
 			expErr:   false,

--- a/pkg/filestore/writer_test.go
+++ b/pkg/filestore/writer_test.go
@@ -314,20 +314,23 @@ func Test_WriteKeypair(t *testing.T) {
 			},
 			expErr: false,
 		},
-		"if key-encoding is PKCS12, correct metadata should be written": {
+		"if keystore-file is set, correct metadata should be written": {
 			testBundle: pkcs8Bundle,
 			meta: metadata.Metadata{
 				VolumeID:   "vol-id",
 				TargetPath: "/target-path",
 				VolumeContext: map[string]string{
 					"csi.cert-manager.io/issuer-name":   "ca-issuer",
-					"csi.cert-manager.io/key-encoding":  "PKCS12",
+					"csi.cert-manager.io/key-encoding":  "PKCS8",
 					"csi.cert-manager.io/keystore-file": "my-file.pfx",
 				},
 			},
 			expFiles: map[string][]byte{
+				"ca.crt":  pkcs8Bundle.caPEM,
+				"tls.crt": pkcs8Bundle.certPEM,
+				"tls.key": pkcs8Bundle.pkPEM,
 				"metadata.json": []byte(
-					`{"volumeID":"vol-id","targetPath":"/target-path","nextIssuanceTime":"1970-01-03T00:00:00Z","volumeContext":{"csi.cert-manager.io/issuer-name":"ca-issuer","csi.cert-manager.io/key-encoding":"PKCS12","csi.cert-manager.io/keystore-file":"my-file.pfx"}}`,
+					`{"volumeID":"vol-id","targetPath":"/target-path","nextIssuanceTime":"1970-01-03T00:00:00Z","volumeContext":{"csi.cert-manager.io/issuer-name":"ca-issuer","csi.cert-manager.io/key-encoding":"PKCS8","csi.cert-manager.io/keystore-file":"my-file.pfx","csi.cert-manager.io/keystore-type":"PKCS12"}}`,
 				),
 			},
 			expErr:   false,


### PR DESCRIPTION
Fixes part of https://github.com/cert-manager/csi-driver/issues/30 (PKCS12 support, but not JKS)

This PR adds two new attributes:
`csi.cert-manager.io/keystore-type` (default value: `pkcs12`, and only option for now)
`csi.cert-manager.io/keystore-file`

If `csi.cert-manager.io/keystore-file` is set, it will be written with the configured `keystore-type` in **addition** to the files we write today.