### PR TITLE
Include pod details in CertificateRequest annotations

### DIFF
--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -39,10 +39,17 @@ const (
 	ReusePrivateKey = "csi.cert-manager.io/reuse-private-key"
 )
 
+// Well-known attribute keys that are present in the volume context, passed
+// from the Kubelet during PublishVolume calls.
 const (
-	// Well-known attribute keys that are present in the volume context, passed
-	// from the Kubelet during PublishVolume calls.
 	K8sVolumeContextKeyPodName      = "csi.storage.k8s.io/pod.name"
 	K8sVolumeContextKeyPodNamespace = "csi.storage.k8s.io/pod.namespace"
 	K8sVolumeContextKeyPodUID       = "csi.storage.k8s.io/pod.uid"
+)
+
+// Common annotations used in generated CertificateRequest resources
+const (
+	PodNameAnnotation      = "csi.cert-manager.io/pod-name"
+	PodNamespaceAnnotation = "csi.cert-manager.io/pod-namespace"
+	PodUIDAnnotation       = "csi.cert-manager.io/pod-uid"
 )

--- a/pkg/requestgen/generator.go
+++ b/pkg/requestgen/generator.go
@@ -73,6 +73,19 @@ func RequestForMetadata(meta metadata.Metadata) (*manager.CertificateRequestBund
 		return nil, fmt.Errorf("%q: %w", csiapi.IPSANsKey, err)
 	}
 
+	annotations := make(map[string]string)
+	if podName, ok := meta.VolumeContext[csiapi.K8sVolumeContextKeyPodName]; ok {
+		annotations[csiapi.PodNameAnnotation] = podName
+	}
+
+	if podNamespace, ok := meta.VolumeContext[csiapi.K8sVolumeContextKeyPodNamespace]; ok {
+		annotations[csiapi.PodNamespaceAnnotation] = podNamespace
+	}
+
+	if podUID, ok := meta.VolumeContext[csiapi.K8sVolumeContextKeyPodUID]; ok {
+		annotations[csiapi.PodUIDAnnotation] = podUID
+	}
+
 	return &manager.CertificateRequestBundle{
 		Request: &x509.CertificateRequest{
 			Subject: pkix.Name{
@@ -91,7 +104,7 @@ func RequestForMetadata(meta metadata.Metadata) (*manager.CertificateRequestBund
 			Kind:  attrs[csiapi.IssuerKindKey],
 			Group: attrs[csiapi.IssuerGroupKey],
 		},
-		Annotations: nil,
+		Annotations: annotations,
 	}, nil
 }
 

--- a/pkg/requestgen/generator_test.go
+++ b/pkg/requestgen/generator_test.go
@@ -31,6 +31,7 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	csiapi "github.com/cert-manager/csi-driver/pkg/apis/v1alpha1"
 )
 
 func Test_RequestForMetadata(t *testing.T) {
@@ -67,6 +68,11 @@ func Test_RequestForMetadata(t *testing.T) {
 				"csi.cert-manager.io/issuer-name": "my-issuer",
 			}}),
 			expRequest: &manager.CertificateRequestBundle{
+				Annotations: map[string]string{
+					csiapi.PodNameAnnotation:      "my-pod-name",
+					csiapi.PodNamespaceAnnotation: "my-namespace",
+					csiapi.PodUIDAnnotation:       "my-pod-uuid",
+				},
 				Request: new(x509.CertificateRequest),
 				IsCA:    false,
 				Usages: []cmapi.KeyUsage{
@@ -145,6 +151,11 @@ func Test_RequestForMetadata(t *testing.T) {
 				"csi.cert-manager.io/key-usages":   "server auth,client auth",
 			}}),
 			expRequest: &manager.CertificateRequestBundle{
+				Annotations: map[string]string{
+					csiapi.PodNameAnnotation:      "my-pod-name",
+					csiapi.PodNamespaceAnnotation: "my-namespace",
+					csiapi.PodUIDAnnotation:       "my-pod-uuid",
+				},
 				Request: &x509.CertificateRequest{
 					Subject: pkix.Name{CommonName: "my-pod-name.my-namespace"},
 					DNSNames: []string{


### PR DESCRIPTION
This commit modifies the generation of CertificateRequest resources to
include pod information obtained from the volume context in its annotations.

Currently, there is no way to link a CertificateRequest to a Pod directly. As
a result, it's hard to determine if the certificate within the request is still
in use. Internally at Jetstack, we want a way to determine if a certificate is
used or not. These annotations will allow us to determine if the Pod requesting
the certificate still exists.

Signed-off-by: David Bond <davidsbond93@gmail.com>