### PR TITLE
Introduce a new filename validation function

### DIFF
--- a/pkg/apis/validation/validation.go
+++ b/pkg/apis/validation/validation.go
@@ -126,6 +126,7 @@ func keyEncodingValue(path *field.Path, s string) field.ErrorList {
 // 2. starting with '..'
 // 3. contain '/'
 // 4. longer than 255 characters
+// 4. include leading or trailing spaces
 func filename(path *field.Path, filename string) field.ErrorList {
 	var el field.ErrorList
 
@@ -133,7 +134,7 @@ func filename(path *field.Path, filename string) field.ErrorList {
 		el = append(el, field.Invalid(path, filename, "filename must not be an absolute path"))
 	}
 
-	if filepath.HasPrefix(filename, "..") {
+	if strings.HasPrefix(filename, "..") {
 		el = append(el, field.Invalid(path, filename, "filename must not start with '..'"))
 	}
 
@@ -144,6 +145,11 @@ func filename(path *field.Path, filename string) field.ErrorList {
 	if len(filename) > 255 {
 		el = append(el, field.Invalid(path, filename, "filename must be no longer than 255 characters"))
 	}
+
+	if filename != strings.TrimSpace(filename) {
+		el = append(el, field.Invalid(path, filename, "filename must not include leading or trailing spaces"))
+	}
+
 	if len(el) > 0 {
 		return el
 	}

--- a/pkg/apis/validation/validation_test.go
+++ b/pkg/apis/validation/validation_test.go
@@ -369,6 +369,14 @@ func Test_PKCS12Values(t *testing.T) {
 			},
 			expErr: nil,
 		},
+		"if key and password is defined, and enabled is defined as true, expect no error foo": {
+			attr: map[string]string{
+				"csi.cert-manager.io/pkcs12-enable":   "true",
+				"csi.cert-manager.io/pkcs12-filename": "/my-file",
+				"csi.cert-manager.io/pkcs12-password": "password",
+			},
+			expErr: nil,
+		},
 	}
 
 	for name, test := range tests {
@@ -402,6 +410,24 @@ func Test_filename(t *testing.T) {
 			filename: "foo/bar",
 			expErr: field.ErrorList{
 				field.Invalid(basePath, "foo/bar", "filename must not include '/'"),
+			},
+		},
+		"a filename which includes ' ' at the beginning should error": {
+			filename: "  foo",
+			expErr: field.ErrorList{
+				field.Invalid(basePath, "  foo", "filename must not include leading or trailing spaces"),
+			},
+		},
+		"a filename which includes ' ' at the end should error": {
+			filename: "foo  ",
+			expErr: field.ErrorList{
+				field.Invalid(basePath, "foo  ", "filename must not include leading or trailing spaces"),
+			},
+		},
+		"a filename which includes ' ' at the end or beginning should error": {
+			filename: " foo ",
+			expErr: field.ErrorList{
+				field.Invalid(basePath, " foo ", "filename must not include leading or trailing spaces"),
 			},
 		},
 		"a filename which is too long should error": {

--- a/pkg/apis/validation/validation_test.go
+++ b/pkg/apis/validation/validation_test.go
@@ -149,11 +149,13 @@ func Test_ValidateAttributes(t *testing.T) {
 			},
 			expErr: field.ErrorList{
 				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/pkcs12-filename"), "../crt.p12",
+					`filename must not start with '..'`),
+				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/pkcs12-filename"), "../crt.p12",
+					`filename must not include '/'`),
+				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/pkcs12-filename"), "../crt.p12",
 					"cannot use attribute without \"csi.cert-manager.io/pkcs12-enable\" set to \"true\" or \"false\""),
 				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/pkcs12-password"), "password",
 					"cannot use attribute without \"csi.cert-manager.io/pkcs12-enable\" set to \"true\" or \"false\""),
-				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/pkcs12-filename"), "../crt.p12",
-					`filepaths may not contain ".."`),
 			},
 		},
 		"setting output filenames which are duplicated should error": {
@@ -187,43 +189,28 @@ func Test_ValidateAttributes(t *testing.T) {
 			},
 			expErr: nil,
 		},
+		"bad filenames for the certificate, key, and ca files should error": {
+			attr: map[string]string{
+				csiapi.IssuerNameKey:  "test-issuer",
+				csiapi.DNSNamesKey:    "foo.bar.com,car.bar.com",
+				csiapi.CAFileKey:      "../foo/../bar",
+				csiapi.KeyEncodingKey: "PKCS8",
+				csiapi.CertFileKey:    "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo",
+				csiapi.KeyFileKey:     "/foobar",
+			},
+			expErr: field.ErrorList{
+				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/ca-file"), "../foo/../bar", "filename must not start with '..'"),
+				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/ca-file"), "../foo/../bar", "filename must not include '/'"),
+				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/certificate-file"), "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo", "filename must be no longer than 255 characters"),
+				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/privatekey-file"), "/foobar", "filename must not be an absolute path"),
+				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/privatekey-file"), "/foobar", "filename must not include '/'"),
+			},
+		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert.EqualValues(t, test.expErr, ValidateAttributes(test.attr))
-		})
-	}
-}
-
-func Test_filepathBreakOut(t *testing.T) {
-	for name, test := range map[string]struct {
-		s      string
-		expErr field.ErrorList
-	}{
-		"normal filepath should not errors": {
-			s:      "foo/bar",
-			expErr: nil,
-		},
-		"no filepath shouldn't error": {
-			s:      "",
-			expErr: nil,
-		},
-		"single dot should not error": {
-			s:      "foo/./bar",
-			expErr: nil,
-		},
-		"two dots should error in middle": {
-			s:      "foo/../bar",
-			expErr: field.ErrorList{field.Invalid(field.NewPath("my-path"), "foo/../bar", `filepaths may not contain ".."`)},
-		},
-		"two dots should error": {
-			s:      "..",
-			expErr: field.ErrorList{field.Invalid(field.NewPath("my-path"), "..", `filepaths may not contain ".."`)},
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expErr, filepathBreakout(field.NewPath("my-path"), test.s))
 		})
 	}
 }
@@ -387,6 +374,59 @@ func Test_PKCS12Values(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert.EqualValues(t, test.expErr, pkcs12Values(basePath, test.attr))
+		})
+	}
+}
+
+func Test_filename(t *testing.T) {
+	basePath := field.NewPath("root")
+
+	tests := map[string]struct {
+		filename string
+		expErr   field.ErrorList
+	}{
+		"a filename which is absolute should error": {
+			filename: "/foo/bar",
+			expErr: field.ErrorList{
+				field.Invalid(basePath, "/foo/bar", "filename must not be an absolute path"),
+				field.Invalid(basePath, "/foo/bar", "filename must not include '/'"),
+			},
+		},
+		"a filename which has a prefix of '..' should error": {
+			filename: "...foobar",
+			expErr: field.ErrorList{
+				field.Invalid(basePath, "...foobar", "filename must not start with '..'"),
+			},
+		},
+		"a filename which includes '/' should error": {
+			filename: "foo/bar",
+			expErr: field.ErrorList{
+				field.Invalid(basePath, "foo/bar", "filename must not include '/'"),
+			},
+		},
+		"a filename which is too long should error": {
+			filename: "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo",
+			expErr: field.ErrorList{
+				field.Invalid(basePath, "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo", "filename must be no longer than 255 characters"),
+			},
+		},
+		"a valid filename should not error": {
+			filename: "foo.bar",
+			expErr:   nil,
+		},
+		"a filename which includes '..' in the middle should not error": {
+			filename: "foo...bar",
+			expErr:   nil,
+		},
+		"a filename which includes '..' at the end should not error": {
+			filename: "foobar...",
+			expErr:   nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expErr, filename(basePath, test.filename))
 		})
 	}
 }

--- a/pkg/filestore/writer_test.go
+++ b/pkg/filestore/writer_test.go
@@ -220,17 +220,17 @@ func Test_WriteKeypair(t *testing.T) {
 				TargetPath: "/target-path",
 				VolumeContext: map[string]string{
 					"csi.cert-manager.io/issuer-name":      "ca-issuer",
-					"csi.cert-manager.io/ca-file":          "foo/bar",
+					"csi.cert-manager.io/ca-file":          "foo",
 					"csi.cert-manager.io/certificate-file": "my-crt",
-					"csi.cert-manager.io/privatekey-file":  "hello/world/key",
+					"csi.cert-manager.io/privatekey-file":  "hello",
 				},
 			},
 			expFiles: map[string][]byte{
-				"foo/bar":         pkcs1Bundle.caPEM,
-				"my-crt":          pkcs1Bundle.certPEM,
-				"hello/world/key": pkcs1Bundle.pkPEM,
+				"foo":    pkcs1Bundle.caPEM,
+				"my-crt": pkcs1Bundle.certPEM,
+				"hello":  pkcs1Bundle.pkPEM,
 				"metadata.json": []byte(
-					`{"volumeID":"vol-id","targetPath":"/target-path","nextIssuanceTime":"1970-01-03T00:00:00Z","volumeContext":{"csi.cert-manager.io/ca-file":"foo/bar","csi.cert-manager.io/certificate-file":"my-crt","csi.cert-manager.io/issuer-name":"ca-issuer","csi.cert-manager.io/privatekey-file":"hello/world/key"}}`,
+					`{"volumeID":"vol-id","targetPath":"/target-path","nextIssuanceTime":"1970-01-03T00:00:00Z","volumeContext":{"csi.cert-manager.io/ca-file":"foo","csi.cert-manager.io/certificate-file":"my-crt","csi.cert-manager.io/issuer-name":"ca-issuer","csi.cert-manager.io/privatekey-file":"hello"}}`,
 				),
 			},
 			expErr: false,

--- a/pkg/filestore/writer_test.go
+++ b/pkg/filestore/writer_test.go
@@ -274,6 +274,25 @@ func Test_WriteKeypair(t *testing.T) {
 			},
 			expErr: true,
 		},
+		"if filename contains bad filenames, expect error": {
+			testBundle: pkcs8Bundle,
+			meta: metadata.Metadata{
+				VolumeID:   "vol-id",
+				TargetPath: "/target-path",
+				VolumeContext: map[string]string{
+					"csi.cert-manager.io/issuer-name":      "ca-issuer",
+					"csi.cert-manager.io/certificate-file": "foo/bar",
+					"csi.cert-manager.io/privatekey-file":  "/foo",
+					"csi.cert-manager.io/ca-file":          "../foo",
+				},
+			},
+			expFiles: map[string][]byte{
+				"metadata.json": []byte(
+					`{"volumeID":"vol-id","targetPath":"/target-path","volumeContext":{"csi.cert-manager.io/ca-file":"../foo","csi.cert-manager.io/certificate-file":"foo/bar","csi.cert-manager.io/issuer-name":"ca-issuer","csi.cert-manager.io/privatekey-file":"/foo"}}`,
+				),
+			},
+			expErr: true,
+		},
 
 		"if encoder is empty, use default encoder PKCS1": {
 			testBundle: pkcs1Bundle,


### PR DESCRIPTION
Based on the conversation [here](https://github.com/cert-manager/csi-driver/pull/103#discussion_r924488984).

This PR introduces a new filename validation function which supersedes the existing `filepathBreakout` function. This new more complete validation includes that included in the [atomic writer](https://github.com/cert-manager/csi-lib/blob/8e344a2d37de27bacb17f8e1d5ddc1f03733351a/third_party/util/atomic_writer.go#L245), as well as ensuring that the filename does not include '/'. 

Whilst most if not more validation now occurs on a filename, it also now occurs earlier in the publish volume pipeline. This is beneficial since we now expose the offending volume attribute in the error message presented to the user.

/assign @munnerz 