### PR TITLE
Add ServiceAccount name as a template value

### DIFF
--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -42,7 +42,8 @@ const (
 const (
 	// Well-known attribute keys that are present in the volume context, passed
 	// from the Kubelet during PublishVolume calls.
-	K8sVolumeContextKeyPodName      = "csi.storage.k8s.io/pod.name"
-	K8sVolumeContextKeyPodNamespace = "csi.storage.k8s.io/pod.namespace"
-	K8sVolumeContextKeyPodUID       = "csi.storage.k8s.io/pod.uid"
+	K8sVolumeContextKeyPodName            = "csi.storage.k8s.io/pod.name"
+	K8sVolumeContextKeyPodNamespace       = "csi.storage.k8s.io/pod.namespace"
+	K8sVolumeContextKeyPodUID             = "csi.storage.k8s.io/pod.uid"
+	K8sVolumeContextKeyServiceAccountName = "csi.storage.k8s.io/serviceAccount.name"
 )

--- a/pkg/requestgen/generator.go
+++ b/pkg/requestgen/generator.go
@@ -181,9 +181,10 @@ func keyUsagesFromAttributes(usagesCSV string) []cmapi.KeyUsage {
 // provided by the metadata.
 func expand(meta metadata.Metadata, csv string) (string, error) {
 	vars := map[string]string{
-		"POD_NAME":      meta.VolumeContext[csiapi.K8sVolumeContextKeyPodName],
-		"POD_NAMESPACE": meta.VolumeContext[csiapi.K8sVolumeContextKeyPodNamespace],
-		"POD_UID":       meta.VolumeContext[csiapi.K8sVolumeContextKeyPodUID],
+		"POD_NAME":             meta.VolumeContext[csiapi.K8sVolumeContextKeyPodName],
+		"POD_NAMESPACE":        meta.VolumeContext[csiapi.K8sVolumeContextKeyPodNamespace],
+		"POD_UID":              meta.VolumeContext[csiapi.K8sVolumeContextKeyPodUID],
+		"SERVICE_ACCOUNT_NAME": meta.VolumeContext[csiapi.K8sVolumeContextKeyServiceAccountName],
 	}
 
 	var errs []string
@@ -198,7 +199,7 @@ func expand(meta metadata.Metadata, csv string) (string, error) {
 	if len(errs) > 0 {
 		return "", fmt.Errorf("%v, known variables: %v",
 			strings.Join(errs, ", "),
-			[]string{"POD_NAME", "POD_NAMESPACE", "POD_UID"},
+			[]string{"POD_NAME", "POD_NAMESPACE", "POD_UID", "SERVICE_ACCOUNT_NAME"},
 		)
 	}
 

--- a/pkg/requestgen/generator_test.go
+++ b/pkg/requestgen/generator_test.go
@@ -216,7 +216,7 @@ func Test_parseDNSNames(t *testing.T) {
 		"if references a variable that doesn't exist, error": {
 			csv:         `$POD_NAME-my-dns-${POD_NAMESPACE}-$POD_UID-$Foo`,
 			expDNSNames: nil,
-			expErr:      errors.New(`undefined variable "Foo", known variables: [POD_NAME POD_NAMESPACE POD_UID]`),
+			expErr:      errors.New(`undefined variable "Foo", known variables: [POD_NAME POD_NAMESPACE POD_UID SERVICE_ACCOUNT_NAME]`),
 		},
 		"a csv containing multiple entries which uses should be substituted correctly": {
 			csv:         `$POD_NAME-my-dns-${POD_NAMESPACE}-$POD_UID,$POD_NAME,$POD_NAME.$POD_NAMESPACE,$POD_NAME.$POD_NAMESPACE.svc,$POD_UID`,
@@ -290,7 +290,7 @@ func Test_URIs(t *testing.T) {
 		"if variables references a variable that doesn't exist, error": {
 			csv:     `$POD_NAME-my-dns-${POD_NAMESPACE}-$POD_UID-${Foo}`,
 			expURIs: nil,
-			expErr:  errors.New(`undefined variable "Foo", known variables: [POD_NAME POD_NAMESPACE POD_UID]`),
+			expErr:  errors.New(`undefined variable "Foo", known variables: [POD_NAME POD_NAMESPACE POD_UID SERVICE_ACCOUNT_NAME]`),
 		},
 		"a csv containing multiple entries which uses variables should be substituted correctly": {
 			csv: `spiffe://$POD_NAME-my-dns-${POD_NAMESPACE}-$POD_UID,spiffe://$POD_NAME,file://${POD_NAME}.$POD_NAMESPACE,$POD_NAME.$POD_NAMESPACE.svc,spiffe://$POD_UID`,
@@ -334,14 +334,14 @@ func Test_expand(t *testing.T) {
 			expErr:    nil,
 		},
 		"if using variables, expect to be substituted": {
-			input:     "foo-$POD_NAME-,,${POD_NAMESPACE},$POD_UID",
-			expOutput: "foo-my-pod-name-,,my-namespace,my-pod-uuid",
+			input:     "foo-$POD_NAME-,,${POD_NAMESPACE},$POD_UID,${SERVICE_ACCOUNT_NAME}",
+			expOutput: "foo-my-pod-name-,,my-namespace,my-pod-uuid,my-service-account",
 			expErr:    nil,
 		},
 		"if reference a variable that does not exist, expect error": {
 			input:     "foo-${POD_NAME}-,,$POD_NAMESPACE,${POD_UID}.$Foo${Bar}",
 			expOutput: "",
-			expErr:    errors.New(`undefined variable "Foo", undefined variable "Bar", known variables: [POD_NAME POD_NAMESPACE POD_UID]`),
+			expErr:    errors.New(`undefined variable "Foo", undefined variable "Bar", known variables: [POD_NAME POD_NAMESPACE POD_UID SERVICE_ACCOUNT_NAME]`),
 		},
 	}
 
@@ -357,10 +357,11 @@ func Test_expand(t *testing.T) {
 func baseMetadata() metadata.Metadata {
 	return metadata.Metadata{
 		VolumeContext: map[string]string{
-			"csi.storage.k8s.io/pod.name":      "my-pod-name",
-			"csi.storage.k8s.io/pod.namespace": "my-namespace",
-			"csi.storage.k8s.io/pod.uid":       "my-pod-uuid",
-			"csi.storage.k8s.io/ephemeral":     "true",
+			"csi.storage.k8s.io/pod.name":            "my-pod-name",
+			"csi.storage.k8s.io/pod.namespace":       "my-namespace",
+			"csi.storage.k8s.io/pod.uid":             "my-pod-uuid",
+			"csi.storage.k8s.io/serviceAccount.name": "my-service-account",
+			"csi.storage.k8s.io/ephemeral":           "true",
 		},
 	}
 }


### PR DESCRIPTION
This enables users to reference the pod's ServiceAccount name in the volumeAttributes.

An example usage would look like:
```yaml
volumeAttributes:
  csi.cert-manager.io/issuer-name: ca-issuer
  csi.cert-manager.io/dns-names: "${POD_NAME}.${POD_NAMESPACE}.svc.cluster.local"
  csi.cert-manager.io/common-name: "${SERVICE_ACCOUNT_NAME}.${POD_NAMESPACE}"
```

This value has been provided by the Kubelet since Kubernetes 1.12, and was merged alongside the other values in kubernetes/kubernetes#67945, so the new map lookup is as safe as the existing ones.

I'll update the docs in a follow up PR

Signed-off-by: Micah Hausler <mhausler@amazon.com>