### PR TITLE
For attributes that are lists, trim space for each entry to improve UX.

### DIFF
--- a/deploy/example/example-app.yaml
+++ b/deploy/example/example-app.yaml
@@ -66,7 +66,7 @@ spec:
             volumeAttributes:
                   csi.cert-manager.io/issuer-name: ca-issuer
                   csi.cert-manager.io/dns-names: >-
-                    ${POD_NAME}.${POD_NAMESPACE}.svc.cluster.local
+                    ${POD_NAME}.${POD_NAMESPACE}.svc.cluster.local,
                     ${POD_NAME}.${POD_NAMESPACE}.svc
                   csi.cert-manager.io/uri-sans: "spiffe://cluster.local/ns/${POD_NAMESPACE}/pod/${POD_NAME}/${POD_UID}"
                   csi.cert-manager.io/pkcs12-enable: "true"

--- a/deploy/example/example-app.yaml
+++ b/deploy/example/example-app.yaml
@@ -65,7 +65,9 @@ spec:
             readOnly: true
             volumeAttributes:
                   csi.cert-manager.io/issuer-name: ca-issuer
-                  csi.cert-manager.io/dns-names: "${POD_NAME}.${POD_NAMESPACE}.svc.cluster.local"
+                  csi.cert-manager.io/dns-names: >-
+                    ${POD_NAME}.${POD_NAMESPACE}.svc.cluster.local
+                    ${POD_NAME}.${POD_NAMESPACE}.svc
                   csi.cert-manager.io/uri-sans: "spiffe://cluster.local/ns/${POD_NAMESPACE}/pod/${POD_NAME}/${POD_UID}"
                   csi.cert-manager.io/pkcs12-enable: "true"
                   csi.cert-manager.io/pkcs12-password: "my-password"

--- a/pkg/requestgen/generator.go
+++ b/pkg/requestgen/generator.go
@@ -105,7 +105,7 @@ func parseDNSNames(meta metadata.Metadata, dnsNames string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return strings.Split(dns, ","), nil
+	return splitList(dns), nil
 }
 
 // parseIPAddresses parses a csi.cert-manager.io/ip-sans value, and returns the
@@ -117,7 +117,7 @@ func parseIPAddresses(ipCSV string) ([]net.IP, error) {
 
 	var ips []net.IP
 	var errs []string
-	for _, ipStr := range strings.Split(ipCSV, ",") {
+	for _, ipStr := range splitList(ipCSV) {
 		ip := net.ParseIP(ipStr)
 		if ip == nil {
 			errs = append(errs, ipStr)
@@ -147,8 +147,8 @@ func parseURIs(meta metadata.Metadata, uriCSV string) ([]*url.URL, error) {
 
 	var uris []*url.URL
 	var errs []string
-	for _, uriS := range strings.Split(csv, ",") {
-		uri, err := url.Parse(uriS)
+	for _, uriS := range splitList(csv) {
+		uri, err := url.ParseRequestURI(uriS)
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue
@@ -170,8 +170,8 @@ func keyUsagesFromAttributes(usagesCSV string) []cmapi.KeyUsage {
 	}
 
 	var keyUsages []cmapi.KeyUsage
-	for _, usage := range strings.Split(usagesCSV, ",") {
-		keyUsages = append(keyUsages, cmapi.KeyUsage(strings.TrimSpace(usage)))
+	for _, usage := range splitList(usagesCSV) {
+		keyUsages = append(keyUsages, cmapi.KeyUsage(usage))
 	}
 
 	return keyUsages
@@ -204,4 +204,13 @@ func expand(meta metadata.Metadata, csv string) (string, error) {
 	}
 
 	return exp, nil
+}
+
+// splitList returns the given csv into a slice. Trims space of each element.
+func splitList(csv string) []string {
+	var list []string
+	for _, s := range strings.Split(csv, ",") {
+		list = append(list, strings.TrimSpace(s))
+	}
+	return list
 }

--- a/pkg/requestgen/generator.go
+++ b/pkg/requestgen/generator.go
@@ -206,7 +206,7 @@ func expand(meta metadata.Metadata, csv string) (string, error) {
 	return exp, nil
 }
 
-// splitList returns the given csv into a slice. Trims space of each element.
+// splitList returns the given csv as a slice. Trims space of each element.
 func splitList(csv string) []string {
 	var list []string
 	for _, s := range strings.Split(csv, ",") {

--- a/test/e2e/suite/cases/variables.go
+++ b/test/e2e/suite/cases/variables.go
@@ -74,8 +74,8 @@ var _ = framework.CasesDescribe("Should correctly substitute out SANs with varia
 			"csi.cert-manager.io/issuer-kind":  f.Issuer.Kind,
 			"csi.cert-manager.io/issuer-group": f.Issuer.Group,
 			"csi.cert-manager.io/common-name":  "$POD_NAME.${POD_NAMESPACE}",
-			"csi.cert-manager.io/dns-names":    "$POD_NAME-my-dns-$POD_NAMESPACE-${POD_UID},${POD_NAME},${POD_NAME}.${POD_NAMESPACE},$POD_NAME.${POD_NAMESPACE}.svc,${POD_UID},${SERVICE_ACCOUNT_NAME}",
-			"csi.cert-manager.io/uri-sans":     "spiffe://foo.bar/${POD_NAMESPACE}/$POD_NAME/$POD_UID,file://foo-bar,${POD_UID}",
+			"csi.cert-manager.io/dns-names":    "$POD_NAME-my-dns-$POD_NAMESPACE-${POD_UID},${POD_NAME},\n${POD_NAME}.${POD_NAMESPACE},$POD_NAME.${POD_NAMESPACE}.svc,${POD_UID},${SERVICE_ACCOUNT_NAME}",
+			"csi.cert-manager.io/uri-sans":     "spiffe://foo.bar/${POD_NAMESPACE}/$POD_NAME/$POD_UID,\nfile://foo-bar,\nbar://${POD_UID}",
 		})
 
 		request, err := pki.DecodeX509CertificateRequestBytes(cr.Spec.Request)
@@ -93,7 +93,7 @@ var _ = framework.CasesDescribe("Should correctly substitute out SANs with varia
 		Expect(request.URIs).To(ConsistOf([]*url.URL{
 			mustParseURI(fmt.Sprintf("spiffe://foo.bar/%s/%s/%s", pod.Namespace, pod.Name, pod.UID)),
 			mustParseURI("file://foo-bar"),
-			mustParseURI(fmt.Sprintf("foo://%s", pod.UID)),
+			mustParseURI(fmt.Sprintf("bar://%s", pod.UID)),
 		}))
 	})
 })

--- a/test/e2e/suite/cases/variables.go
+++ b/test/e2e/suite/cases/variables.go
@@ -62,7 +62,7 @@ var _ = framework.CasesDescribe("Should correctly substitute out SANs with varia
 	}
 
 	mustParseURI := func(uri string) *url.URL {
-		puri, err := url.Parse(uri)
+		puri, err := url.ParseRequestURI(uri)
 		Expect(err).NotTo(HaveOccurred())
 		return puri
 	}
@@ -93,7 +93,7 @@ var _ = framework.CasesDescribe("Should correctly substitute out SANs with varia
 		Expect(request.URIs).To(ConsistOf([]*url.URL{
 			mustParseURI(fmt.Sprintf("spiffe://foo.bar/%s/%s/%s", pod.Namespace, pod.Name, pod.UID)),
 			mustParseURI("file://foo-bar"),
-			mustParseURI(string(pod.UID)),
+			mustParseURI(fmt.Sprintf("foo://%s", pod.UID)),
 		}))
 	})
 })


### PR DESCRIPTION
Fixes #111 

PR trims the spaces of attributes which are lists. This improves UX, and enables the example given in the issue.

Updates the example deployment making use of the change.

PR also tightens validation to enforce proper URIs are passers to the URI sans attribute.

/assign @munnerz 