### PR TITLE
Remove extra } from the sample uri-san

### DIFF
--- a/deploy/example/example-app.yaml
+++ b/deploy/example/example-app.yaml
@@ -66,7 +66,7 @@ spec:
             volumeAttributes:
                   csi.cert-manager.io/issuer-name: ca-issuer
                   csi.cert-manager.io/dns-names: "${POD_NAME}.${POD_NAMESPACE}.svc.cluster.local"
-                  csi.cert-manager.io/uri-sans: "spiffe://cluster.local/ns/${POD_NAMESPACE}/pod/${POD_NAME}}/${POD_UID}"
+                  csi.cert-manager.io/uri-sans: "spiffe://cluster.local/ns/${POD_NAMESPACE}/pod/${POD_NAME}/${POD_UID}"
                   csi.cert-manager.io/pkcs12-enable: "true"
                   csi.cert-manager.io/pkcs12-password: "my-password"
                   csi.cert-manager.io/pkcs12-filename: "crt.p12"


### PR DESCRIPTION
Signed-off-by: Sitaram IYER <sitaramkm@gmail.com>

Minor update to sample. remove the additional } from the uri-sans. Doesn't break anything. 