### PR TITLE
Use latest CSI sidecar container images from registry.k8s.io

### DIFF
--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -32,11 +32,11 @@ A Helm chart for cert-manager-csi-driver
 | image.tag | string | `"v0.4.0"` | Target image version tag. |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the csi-driver container image |
 | livenessProbeImage.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on liveness probe. |
-| livenessProbeImage.repository | string | `"k8s.gcr.io/sig-storage/livenessprobe"` | Target image repository. |
-| livenessProbeImage.tag | string | `"v2.6.0"` | Target image version tag. |
+| livenessProbeImage.repository | string | `"registry.k8s.io/sig-storage/livenessprobe"` | Target image repository. |
+| livenessProbeImage.tag | string | `"v2.9.0"` | Target image version tag. |
 | nodeDriverRegistrarImage.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on node-driver. |
-| nodeDriverRegistrarImage.repository | string | `"k8s.gcr.io/sig-storage/csi-node-driver-registrar"` | Target image repository. |
-| nodeDriverRegistrarImage.tag | string | `"v2.5.0"` | Target image version tag. |
+| nodeDriverRegistrarImage.repository | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar"` | Target image repository. |
+| nodeDriverRegistrarImage.tag | string | `"v2.7.0"` | Target image version tag. |
 | nodeSelector | object | `{}` |  |
 | resources | object | `{}` |  |
 | tolerations | list | `[]` |  |

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -12,17 +12,17 @@ imagePullSecrets: []
   
 nodeDriverRegistrarImage:
   # -- Target image repository.
-  repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
   # -- Target image version tag.
-  tag: v2.5.0
+  tag: v2.7.0
   # -- Kubernetes imagePullPolicy on node-driver.
   pullPolicy: IfNotPresent
 
 livenessProbeImage:
   # -- Target image repository.
-  repository: k8s.gcr.io/sig-storage/livenessprobe
+  repository: registry.k8s.io/sig-storage/livenessprobe
   # -- Target image version tag.
-  tag: v2.6.0
+  tag: v2.9.0
   # -- Kubernetes imagePullPolicy on liveness probe.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
k8s.gcr.io registry is deprecated and to be shut down https://groups.google.com/a/kubernetes.io/g/dev/c/DYZYNQ_A6_c


This PR changes the registry of upstream CSI driver sidecar images to the new registry.k8s.io and also bumps to the latest minor versions of those images. I've tested that CSI driver with these images work as expected.

