### PR TITLE
Add explicit namespace to namespaced resources + bump versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ BINDIR ?= $(CURDIR)/bin
 ARCH   ?= $(shell go env GOARCH)
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
 
-APP_VERSION ?= v0.6.0
-HELM_VERSION ?= 3.13.2
+APP_VERSION ?= v0.6.1
+HELM_VERSION ?= 3.13.3
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)

--- a/deploy/charts/csi-driver/Chart.yaml
+++ b/deploy/charts/csi-driver/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 sources:
 - https://github.com/cert-manager/csi-driver
 
-appVersion: v0.6.0
-version: v0.6.0
+appVersion: v0.6.1
+version: v0.6.1

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -1,6 +1,6 @@
 # cert-manager-csi-driver
 
-![Version: v0.6.0](https://img.shields.io/badge/Version-v0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
+![Version: v0.6.1](https://img.shields.io/badge/Version-v0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.1](https://img.shields.io/badge/AppVersion-v0.6.1-informational?style=flat-square)
 
 cert-manager-csi-driver enables issuing secretless X.509 certificates for pods using cert-manager
 
@@ -33,14 +33,14 @@ cert-manager-csi-driver enables issuing secretless X.509 certificates for pods u
 | daemonSetAnnotations | object | `{}` | Optional additional annotations to add to the csi-driver DaemonSet |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on csi-driver. |
 | image.repository | string | `"quay.io/jetstack/cert-manager-csi-driver"` | Target image repository. |
-| image.tag | string | `"v0.6.0"` | Target image version tag. |
+| image.tag | string | `"v0.6.1"` | Target image version tag. |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the csi-driver container image |
 | livenessProbeImage.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on liveness probe. |
 | livenessProbeImage.repository | string | `"registry.k8s.io/sig-storage/livenessprobe"` | Target image repository. |
-| livenessProbeImage.tag | string | `"v2.9.0"` | Target image version tag. |
+| livenessProbeImage.tag | string | `"v2.11.0"` | Target image version tag. |
 | nodeDriverRegistrarImage.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on node-driver. |
 | nodeDriverRegistrarImage.repository | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar"` | Target image repository. |
-| nodeDriverRegistrarImage.tag | string | `"v2.9.1"` | Target image version tag. |
+| nodeDriverRegistrarImage.tag | string | `"v2.9.2"` | Target image version tag. |
 | nodeSelector | object | `{}` | Kubernetes node selector: node labels for pod assignment |
 | podAnnotations | object | `{}` | Optional additional annotations to add to the csi-driver Pods |
 | podLabels | object | `{}` | Optional additional labels to add to the csi-driver Pods |

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "cert-manager-csi-driver.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "cert-manager-csi-driver.labels" . | indent 4 }}
   {{- with .Values.daemonSetAnnotations }}

--- a/deploy/charts/csi-driver/templates/serviceaccount.yaml
+++ b/deploy/charts/csi-driver/templates/serviceaccount.yaml
@@ -8,3 +8,4 @@ metadata:
   labels:
 {{ include "cert-manager-csi-driver.labels" . | indent 4 }}
   name: {{ include "cert-manager-csi-driver.name" . }}
+  namespace: {{ .Release.Namespace | quote }}

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -2,7 +2,7 @@ image:
   # -- Target image repository.
   repository: quay.io/jetstack/cert-manager-csi-driver
   # -- Target image version tag.
-  tag: v0.6.0
+  tag: v0.6.1
   # -- Kubernetes imagePullPolicy on csi-driver.
   pullPolicy: IfNotPresent
   # Setting a digest will override any tag
@@ -19,7 +19,7 @@ nodeDriverRegistrarImage:
   # -- Target image repository.
   repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
   # -- Target image version tag.
-  tag: v2.9.1
+  tag: v2.9.2
   # -- Kubernetes imagePullPolicy on node-driver.
   pullPolicy: IfNotPresent
 
@@ -27,7 +27,7 @@ livenessProbeImage:
   # -- Target image repository.
   repository: registry.k8s.io/sig-storage/livenessprobe
   # -- Target image version tag.
-  tag: v2.9.0
+  tag: v2.11.0
   # -- Kubernetes imagePullPolicy on liveness probe.
   pullPolicy: IfNotPresent
   # Setting a digest will override any tag


### PR DESCRIPTION
This improves compatibility with helm template. This PR is based on https://github.com/cert-manager/approver-policy/pull/170

There aren't many resources defined in this chart, so there's not much to change here

This also bumps our version for a release, and bumps some k8s images we depend on. The livenessprobe image has increased by 2 minor versions here, but the [changelogs](https://github.com/kubernetes-csi/livenessprobe/tree/master/CHANGELOG) seem to indicate that the upgrades are bug fixes or CVE fixes. It seems safe to bump these in a patch release.