### PR TITLE
Upgrade 'csi-node-driver-registrar' and 'livenessprobe'

### DIFF
--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -33,14 +33,14 @@ cert-manager-csi-driver enables issuing secretless X.509 certificates for pods u
 | daemonSetAnnotations | object | `{}` | Optional additional annotations to add to the csi-driver DaemonSet |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on csi-driver. |
 | image.repository | string | `"quay.io/jetstack/cert-manager-csi-driver"` | Target image repository. |
-| image.tag | string | `"v0.6.1"` | Target image version tag. |
+| image.tag | string | `"v0.0.0"` | Target image version tag. |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the csi-driver container image |
 | livenessProbeImage.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on liveness probe. |
 | livenessProbeImage.repository | string | `"registry.k8s.io/sig-storage/livenessprobe"` | Target image repository. |
-| livenessProbeImage.tag | string | `"v2.11.0"` | Target image version tag. |
+| livenessProbeImage.tag | string | `"v2.12.0"` | Target image version tag. |
 | nodeDriverRegistrarImage.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on node-driver. |
 | nodeDriverRegistrarImage.repository | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar"` | Target image repository. |
-| nodeDriverRegistrarImage.tag | string | `"v2.9.2"` | Target image version tag. |
+| nodeDriverRegistrarImage.tag | string | `"v2.10.0"` | Target image version tag. |
 | nodeSelector | object | `{}` | Kubernetes node selector: node labels for pod assignment |
 | podAnnotations | object | `{}` | Optional additional annotations to add to the csi-driver Pods |
 | podLabels | object | `{}` | Optional additional labels to add to the csi-driver Pods |

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -2,7 +2,7 @@ image:
   # -- Target image repository.
   repository: quay.io/jetstack/cert-manager-csi-driver
   # -- Target image version tag.
-  tag: v0.6.1
+  tag: v0.0.0
   # -- Kubernetes imagePullPolicy on csi-driver.
   pullPolicy: IfNotPresent
   # Setting a digest will override any tag
@@ -19,7 +19,7 @@ nodeDriverRegistrarImage:
   # -- Target image repository.
   repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
   # -- Target image version tag.
-  tag: v2.9.2
+  tag: v2.10.0
   # -- Kubernetes imagePullPolicy on node-driver.
   pullPolicy: IfNotPresent
 
@@ -27,7 +27,7 @@ livenessProbeImage:
   # -- Target image repository.
   repository: registry.k8s.io/sig-storage/livenessprobe
   # -- Target image version tag.
-  tag: v2.11.0
+  tag: v2.12.0
   # -- Kubernetes imagePullPolicy on liveness probe.
   pullPolicy: IfNotPresent
   # Setting a digest will override any tag


### PR DESCRIPTION
Bump the versions of the 'csi-node-driver-registrar' and 'livenessprobe' images.
Also set the version of our own image to v0.0.0 to make clear that this gets replaced before publishing.