### PR TITLE
Use helm-tool for generating helm docs

### DIFF
--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -17,34 +17,486 @@ cert-manager-csi-driver enables issuing secretless X.509 certificates for pods u
 * <https://github.com/cert-manager/csi-driver>
 
 ## Values
+<!-- AUTO-GENERATED -->
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` | Kubernetes affinity: constraints for pod assignment |
-| app.driver | object | `{"csiDataDir":"/tmp/cert-manager-csi-driver","name":"csi.cert-manager.io","useTokenRequest":false}` | Options for CSI driver |
-| app.driver.csiDataDir | string | `"/tmp/cert-manager-csi-driver"` | Configures the hostPath directory that the driver will write and mount volumes from. |
-| app.driver.name | string | `"csi.cert-manager.io"` | Name of the driver which will be registered with Kubernetes. |
-| app.driver.useTokenRequest | bool | `false` | If enabled, will use CSI token request for creating CertificateRequests. CertificateRequests will be created via mounting pod's service accounts. |
-| app.kubeletRootDir | string | `"/var/lib/kubelet"` | Overrides path to root kubelet directory in case of a non-standard k8s install. |
-| app.livenessProbe | object | `{"port":9809}` | Options for the liveness container. |
-| app.livenessProbe.port | int | `9809` | The port that will expose the livness of the csi-driver |
-| app.logLevel | int | `1` | Verbosity of cert-manager-csi-driver logging. |
-| commonLabels | object | `{}` | Labels to apply to all resources |
-| daemonSetAnnotations | object | `{}` | Optional additional annotations to add to the csi-driver DaemonSet |
-| image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on csi-driver. |
-| image.repository | string | `"quay.io/jetstack/cert-manager-csi-driver"` | Target image repository. |
-| image.tag | string | `"v0.0.0"` | Target image version tag. |
-| imagePullSecrets | list | `[]` | Optional secrets used for pulling the csi-driver container image |
-| livenessProbeImage.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on liveness probe. |
-| livenessProbeImage.repository | string | `"registry.k8s.io/sig-storage/livenessprobe"` | Target image repository. |
-| livenessProbeImage.tag | string | `"v2.12.0"` | Target image version tag. |
-| nodeDriverRegistrarImage.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on node-driver. |
-| nodeDriverRegistrarImage.repository | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar"` | Target image repository. |
-| nodeDriverRegistrarImage.tag | string | `"v2.10.0"` | Target image version tag. |
-| nodeSelector | object | `{}` | Kubernetes node selector: node labels for pod assignment |
-| podAnnotations | object | `{}` | Optional additional annotations to add to the csi-driver Pods |
-| podLabels | object | `{}` | Optional additional labels to add to the csi-driver Pods |
-| priorityClassName | string | `""` | Optional priority class to be used for the csi-driver pods. |
-| resources | object | `{}` | Kubernetes pod resources requests/limits for cert-manager-csi-driver |
-| tolerations | list | `[]` | Kubernetes pod tolerations for cert-manager-csi-driver |
 
+<table>
+<tr>
+<th>Property</th>
+<th>Description</th>
+<th>Type</th>
+<th>Default</th>
+</tr>
+<tr>
+
+<td>image.repository</td>
+<td>
+
+Target image repository.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+quay.io/jetstack/cert-manager-csi-driver
+```
+
+</td>
+</tr>
+<tr>
+
+<td>image.tag</td>
+<td>
+
+Target image version tag.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+v0.0.0
+```
+
+</td>
+</tr>
+<tr>
+
+<td>image.pullPolicy</td>
+<td>
+
+Kubernetes imagePullPolicy on csi-driver.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+IfNotPresent
+```
+
+</td>
+</tr>
+<tr>
+
+<td>imagePullSecrets</td>
+<td>
+
+Optional secrets used for pulling the csi-driver container image  
+  
+For example:
+
+```yaml
+imagePullSecrets:
+- name: secret-name
+```
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
+<td>commonLabels</td>
+<td>
+
+Labels to apply to all resources
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>nodeDriverRegistrarImage.repository</td>
+<td>
+
+Target image repository.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+registry.k8s.io/sig-storage/csi-node-driver-registrar
+```
+
+</td>
+</tr>
+<tr>
+
+<td>nodeDriverRegistrarImage.tag</td>
+<td>
+
+Target image version tag.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+v2.10.0
+```
+
+</td>
+</tr>
+<tr>
+
+<td>nodeDriverRegistrarImage.pullPolicy</td>
+<td>
+
+Kubernetes imagePullPolicy on node-driver.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+IfNotPresent
+```
+
+</td>
+</tr>
+<tr>
+
+<td>livenessProbeImage.repository</td>
+<td>
+
+Target image repository.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+registry.k8s.io/sig-storage/livenessprobe
+```
+
+</td>
+</tr>
+<tr>
+
+<td>livenessProbeImage.tag</td>
+<td>
+
+Target image version tag.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+v2.12.0
+```
+
+</td>
+</tr>
+<tr>
+
+<td>livenessProbeImage.pullPolicy</td>
+<td>
+
+Kubernetes imagePullPolicy on liveness probe.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+IfNotPresent
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.logLevel</td>
+<td>
+
+Verbosity of cert-manager-csi-driver logging.
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+1
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.driver.name</td>
+<td>
+
+Name of the driver which will be registered with Kubernetes.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+csi.cert-manager.io
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.driver.useTokenRequest</td>
+<td>
+
+If enabled, will use CSI token request for creating. CertificateRequests. CertificateRequests will be created via mounting pod's service accounts.
+
+</td>
+<td>bool</td>
+<td>
+
+```yaml
+false
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.driver.csiDataDir</td>
+<td>
+
+Configures the hostPath directory that the driver will write and mount volumes from.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+/tmp/cert-manager-csi-driver
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.livenessProbe.port</td>
+<td>
+
+The port that will expose the livness of the csi-driver
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+9809
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.kubeletRootDir</td>
+<td>
+
+Overrides path to root kubelet directory in case of a non-standard k8s install.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+/var/lib/kubelet
+```
+
+</td>
+</tr>
+<tr>
+
+<td>daemonSetAnnotations</td>
+<td>
+
+Optional additional annotations to add to the csi-driver DaemonSet
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>podAnnotations</td>
+<td>
+
+Optional additional annotations to add to the csi-driver Pods
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>podLabels</td>
+<td>
+
+Optional additional labels to add to the csi-driver Pods
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>resources</td>
+<td>
+
+Kubernetes pod resources requests/limits for cert-manager-csi-driver  
+  
+For example:
+
+```yaml
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+```
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>nodeSelector</td>
+<td>
+
+Kubernetes node selector: node labels for pod assignment. For example, to allow scheduling of DaemonSet on linux nodes only:
+
+```yaml
+nodeSelector:
+  kubernetes.io/os: linux
+```
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>affinity</td>
+<td>
+
+Kubernetes affinity: constraints for pod assignment  
+  
+For example:
+
+```yaml
+affinity:
+  nodeAffinity:
+   requiredDuringSchedulingIgnoredDuringExecution:
+     nodeSelectorTerms:
+     - matchExpressions:
+       - key: foo.bar.com/role
+         operator: In
+         values:
+         - master
+```
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>tolerations</td>
+<td>
+
+Kubernetes pod tolerations for cert-manager-csi-driver  
+  
+For example:
+
+```yaml
+tolerations:
+- operator: "Exists"
+```
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
+<td>priorityClassName</td>
+<td>
+
+Optional priority class to be used for the csi-driver pods.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+""
+```
+
+</td>
+</tr>
+</table>
+
+<!-- /AUTO-GENERATED -->

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -1,96 +1,108 @@
 image:
-  # -- Target image repository.
+  # Target image repository.
   repository: quay.io/jetstack/cert-manager-csi-driver
-  # -- Target image version tag.
+  # Target image version tag.
   tag: v0.0.0
-  # -- Kubernetes imagePullPolicy on csi-driver.
+  # Kubernetes imagePullPolicy on csi-driver.
   pullPolicy: IfNotPresent
   # Setting a digest will override any tag
   # digest: sha256:xxxx
 
-# -- Optional secrets used for pulling the csi-driver container image
+# Optional secrets used for pulling the csi-driver container image
+#
+# For example:
+#  imagePullSecrets:
+#  - name: secret-name
 imagePullSecrets: []
-#- name: Secret with Registry credentials
 
-# -- Labels to apply to all resources
+# Labels to apply to all resources
 commonLabels: {}
 
 nodeDriverRegistrarImage:
-  # -- Target image repository.
+  # Target image repository.
   repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
-  # -- Target image version tag.
+  # Target image version tag.
   tag: v2.10.0
-  # -- Kubernetes imagePullPolicy on node-driver.
+  # Kubernetes imagePullPolicy on node-driver.
   pullPolicy: IfNotPresent
 
 livenessProbeImage:
-  # -- Target image repository.
+  # Target image repository.
   repository: registry.k8s.io/sig-storage/livenessprobe
-  # -- Target image version tag.
+  # Target image version tag.
   tag: v2.12.0
-  # -- Kubernetes imagePullPolicy on liveness probe.
+  # Kubernetes imagePullPolicy on liveness probe.
   pullPolicy: IfNotPresent
   # Setting a digest will override any tag
   # digest: sha256:xxxx
 
 app:
-  # -- Verbosity of cert-manager-csi-driver logging.
+  # Verbosity of cert-manager-csi-driver logging.
   logLevel: 1 # 1-5
-  # -- Options for CSI driver
+  # Options for CSI driver
   driver:
-    # -- Name of the driver which will be registered with Kubernetes.
+    # Name of the driver which will be registered with Kubernetes.
     name: csi.cert-manager.io
-    # -- If enabled, will use CSI token request for creating
+    # If enabled, will use CSI token request for creating
     # CertificateRequests. CertificateRequests will be created via mounting
     # pod's service accounts.
     useTokenRequest: false
-    # -- Configures the hostPath directory that the driver will write and mount volumes from.
+    # Configures the hostPath directory that the driver will write and mount volumes from.
     csiDataDir: /tmp/cert-manager-csi-driver
-  # -- Options for the liveness container.
+  # Options for the liveness container.
   livenessProbe:
-    # -- The port that will expose the livness of the csi-driver
+    # The port that will expose the livness of the csi-driver
     port: 9809
-  # -- Overrides path to root kubelet directory in case of a non-standard k8s install.
+  # Overrides path to root kubelet directory in case of a non-standard k8s install.
   kubeletRootDir: /var/lib/kubelet
 
-# -- Optional additional annotations to add to the csi-driver DaemonSet
+# Optional additional annotations to add to the csi-driver DaemonSet
 daemonSetAnnotations: {}
 
-# -- Optional additional annotations to add to the csi-driver Pods
+# Optional additional annotations to add to the csi-driver Pods
 podAnnotations: {}
 
-# -- Optional additional labels to add to the csi-driver Pods
+# Optional additional labels to add to the csi-driver Pods
 podLabels: {}
 
-# -- Kubernetes pod resources requests/limits for cert-manager-csi-driver
+# Kubernetes pod resources requests/limits for cert-manager-csi-driver
+#
+# For example:
+#  resources:
+#    limits:
+#      cpu: 100m
+#      memory: 128Mi
+#    requests:
+#      cpu: 100m
+#      memory: 128Mi
 resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
-# -- Kubernetes node selector: node labels for pod assignment
+# Kubernetes node selector: node labels for pod assignment.
+# For example, to allow scheduling of DaemonSet on linux nodes only:
+#  nodeSelector:
+#    kubernetes.io/os: linux
 nodeSelector: {}
-  # -- Allow scheduling of DaemonSet on linux nodes only
-  # kubernetes.io/os: linux
 
-# -- Kubernetes affinity: constraints for pod assignment
+# Kubernetes affinity: constraints for pod assignment
+# 
+# For example:
+#  affinity:
+#    nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#       - matchExpressions:
+#         - key: foo.bar.com/role
+#           operator: In
+#           values:
+#           - master
 affinity: {}
-  # nodeAffinity:
-  #  requiredDuringSchedulingIgnoredDuringExecution:
-  #    nodeSelectorTerms:
-  #    - matchExpressions:
-  #      - key: foo.bar.com/role
-  #        operator: In
-  #        values:
-  #        - master
 
-# -- Kubernetes pod tolerations for cert-manager-csi-driver
+# Kubernetes pod tolerations for cert-manager-csi-driver
+#
+# For example:
+#  tolerations:
+#  - operator: "Exists"
 tolerations: []
-  # -- Allow scheduling of DaemonSet on all nodes
-  # - operator: "Exists"
 
-# -- Optional priority class to be used for the csi-driver pods.
+# Optional priority class to be used for the csi-driver pods.
 priorityClassName: ""

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -38,6 +38,8 @@ api_docs_branch := main
 helm_chart_source_dir := deploy/charts/csi-driver
 helm_chart_name := cert-manager-csi-driver
 helm_chart_version := $(VERSION)
+helm_docs_use_helm_tool := 1
+
 define helm_values_mutation_function
 $(YQ) \
 	'( .image.repository = "$(oci_manager_image_name)" ) | \


### PR DESCRIPTION
Part of moving everything to a common format/tool for helm docs.

Preview of the changes can be seen here:
https://github.com/ThatsMrTalbot/cert-manager-csi-driver/blob/feat/helm-tool-for-docs/deploy/charts/csi-driver/README.md

Depends on this PR being merged first https://github.com/cert-manager/csi-driver/pull/181