### PR TITLE
Add version info to binary at compile time

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/cert-manager/csi-driver/cmd/app/options"
+	"github.com/cert-manager/csi-driver/internal/version"
 	csiapi "github.com/cert-manager/csi-driver/pkg/apis/v1alpha1"
 	"github.com/cert-manager/csi-driver/pkg/filestore"
 	"github.com/cert-manager/csi-driver/pkg/keygen"
@@ -56,7 +57,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log := opts.Logr.WithName("main")
-			log.Info("building driver")
+			log.Info("Version", "info", version.VersionInfo())
 
 			store, err := storage.NewFilesystem(opts.Logr.WithName("storage"), opts.DataRoot)
 			if err != nil {
@@ -75,7 +76,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 			mngrlog := opts.Logr.WithName("manager")
 			d, err := driver.New(opts.Endpoint, opts.Logr.WithName("driver"), driver.Options{
 				DriverName:    opts.DriverName,
-				DriverVersion: "v0.3.0",
+				DriverVersion: version.AppVersion,
 				NodeID:        opts.NodeID,
 				Store:         store,
 				Manager: manager.NewManagerOrDie(manager.Options{

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -57,7 +57,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log := opts.Logr.WithName("main")
-			log.Info("Version", "info", version.VersionInfo())
+			log.Info("Starting driver", "version", version.VersionInfo())
 
 			store, err := storage.NewFilesystem(opts.Logr.WithName("storage"), opts.DataRoot)
 			if err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+func init() {
+	if AppVersion == "" || GitCommit == "" {
+		fmt.Fprintf(os.Stderr, "warning: AppVersion or GitCommit not set, this binary was built without -ldflags \"-X internal/version.AppVersion=... -X internal/version.GitCommit=...\"\n")
+	}
+}
+
+type Version struct {
+	AppVersion string `json:"appVersion"`
+	GitCommit  string `json:"gitCommit"`
+	GoVersion  string `json:"goVersion"`
+	Compiler   string `json:"compiler"`
+	Platform   string `json:"platform"`
+}
+
+// This variable block holds information used to build up the version string
+var (
+	AppVersion = ""
+	GitCommit  = ""
+)
+
+func VersionInfo() Version {
+	return Version{
+		AppVersion: AppVersion,
+		GitCommit:  GitCommit,
+		GoVersion:  runtime.Version(),
+		Compiler:   runtime.Compiler,
+		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
Prints the version info on startup and passes the version string to csi-lib.