### PR TITLE
Use CSIDriver v1 unconditionally

### DIFF
--- a/deploy/charts/csi-driver/templates/csidriver.yaml
+++ b/deploy/charts/csi-driver/templates/csidriver.yaml
@@ -1,8 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "storage.k8s.io/v1/CSIDriver" }}
 apiVersion: storage.k8s.io/v1
-{{- else }}
-apiVersion: storage.k8s.io/v1beta1
-{{- end }}
 kind: CSIDriver
 metadata:
   name: {{ .Values.app.driver.name }}


### PR DESCRIPTION
v1beta1 is no longer served as of k8s 1.22, and v1 has been available since k8s 1.19. There's no point in checking this any more; the oldest version of k8s we support with cert-manager is v1.22.