### PR TITLE
Add default container annotation to daemonset

### DIFF
--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -21,10 +21,11 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        kubectl.kubernetes.io/default-container: cert-manager-csi-driver
+        {{- if .Values.podAnnotations }}
+          {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
There's a [standard annotation](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container) which specifies the default container for a pod with multiple containers. This changes the default container for log output when using `kubectl logs`.

I think the csi-driver container itself is a sensible default, so this PR adds that.

Tested locally with:

```console
$ cat values.yaml
podAnnotations:
  example.com/annotation: hello-world

$ helm upgrade -i -n cert-manager cert-manager-csi-driver ./deploy/charts/csi-driver --set image.tag=v0.7.1 --wait --values values.yaml

$ kubectl get pods -n cert-manager cert-manager-csi-driver-qt88j -ojson | jq -r .metadata.annotations
{
  "example.com/annotation": "hello-world",
  "kubectl.kubernetes.io/default-container": "cert-manager-csi-driver"
}

$ kubectl logs -n cert-manager cert-manager-csi-driver-qt88j
<logs for csi-driver>
```