### PR TITLE
Add initial documentation of release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,36 @@ the features that cert-manager provides.
 Please follow the documentation at
 [cert-manager.io](https://cert-manager.io/docs/projects/csi-driver/) for
 installing and using csi-driver.
+
+## Release Process
+
+There is a semi-automated release process for csi-driver.
+When you create a Git tag with a tagname that has a `v` prefix and push it to GitHub
+it will trigger the [release workflow].
+
+This will:
+
+1. Create and push a Docker image to `quay.io/jetstack/cert-manager-csi-driver:${{ github.ref_name }}`
+2. Create a Helm chart
+3. Create a *draft* GitHub release with the Helm chart file attached and containing a reference to the Docker image.
+
+To perform a release:
+
+1. Create and push a Git tag
+
+   ```sh
+   export VERSION=v0.5.0-alpha.0
+   git tag --annotate --message="Release ${VERSION}" "${VERSION}"
+   git push origin "${VERSION}"
+   ```
+
+2. Wait for the [release workflow] to succeed and if successful visit the draft release page to download the attached Helm chart attachment.
+
+3. Create a PR in the [jetstack/jetstack-charts repository on GitHub](https://github.com/jetstack/jetstack-charts), containing the Helm chart file that is attached to the draft GitHub release. This is only currently possible for maintainers inside Venafi, but will be changed in the future.
+
+4. Wait for the PR to be merged and verify that the Helm chart is available from https://charts.jetstack.io.
+
+5. Visit the [releases page], edit the draft release, click "Generate release notes", and publish the release.
+
+[release workflow]: https://github.com/cert-manager/csi-driver/actions/workflows/release.yaml
+[releases page]: https://github.com/cert-manager/csi-driver/releases


### PR DESCRIPTION
In time, we should have a central point for this kind of documentation since the process should be similar across most repos. That's tracked in https://github.com/cert-manager/makefile-modules/issues/98

For now, it's important to have at least some documentation in this repo of the process. This description is mostly copied from https://github.com/cert-manager/approver-policy/blob/135f48c7dc2137a3bae8cd71cdf2059f5843445c/README.md#release-process