### PR TITLE
Add attribute support for certificate subject

### DIFF
--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -21,7 +21,17 @@ const (
 	IssuerKindKey  = "csi.cert-manager.io/issuer-kind"
 	IssuerGroupKey = "csi.cert-manager.io/issuer-group"
 
-	CommonNameKey  = "csi.cert-manager.io/common-name"
+	LiteralSubjectKey      = "csi.cert-manager.io/literal-subject"
+	CommonNameKey          = "csi.cert-manager.io/common-name"
+	OrganizationsKey       = "csi.cert-manager.io/organizations"
+	OrganizationalUnitsKey = "csi.cert-manager.io/organizationalunits"
+	CountriesKey           = "csi.cert-manager.io/countries"
+	ProvincesKey           = "csi.cert-manager.io/provinces"
+	LocalitiesKey          = "csi.cert-manager.io/localities"
+	StreetAddressesKey     = "csi.cert-manager.io/streetaddresses"
+	PostalCodesKey         = "csi.cert-manager.io/postalcodes"
+	SerialNumberKey        = "csi.cert-manager.io/serialnumber"
+
 	DNSNamesKey    = "csi.cert-manager.io/dns-names"
 	IPSANsKey      = "csi.cert-manager.io/ip-sans"
 	URISANsKey     = "csi.cert-manager.io/uri-sans"

--- a/pkg/apis/validation/validation_test.go
+++ b/pkg/apis/validation/validation_test.go
@@ -27,6 +27,13 @@ import (
 )
 
 func Test_ValidateAttributes(t *testing.T) {
+	type vaT struct {
+		attr     map[string]string
+		expError error
+	}
+
+	var literalSubject = "CN=${POD_NAME}.${POD_NAMESPACE}.svc.cluster.local,OU=0:${POD_NAME}\\;1:${POD_NAMESPACE}\\;2:my-region\\;4:unittest,O=foo.bar.com"
+
 	tests := map[string]struct {
 		attr   map[string]string
 		expErr field.ErrorList
@@ -200,6 +207,18 @@ func Test_ValidateAttributes(t *testing.T) {
 				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/privatekey-file"), "/foobar", "filename must not be an absolute path"),
 				field.Invalid(field.NewPath("volumeAttributes", "csi.cert-manager.io/privatekey-file"), "/foobar", "filename must not include '/'"),
 			},
+		},
+		"correct literal-subject should not error": {
+			attr: map[string]string{
+				csiapi.IssuerNameKey:     "test-issuer",
+				csiapi.LiteralSubjectKey: literalSubject,
+				csiapi.CAFileKey:         "ca.crt",
+				csiapi.CertFileKey:       "crt.tls",
+				csiapi.KeyFileKey:        "key.tls",
+				csiapi.DNSNamesKey:       "foo.bar.com",
+				csiapi.KeyEncodingKey:    "PKCS8",
+			},
+			expErr: nil,
 		},
 	}
 

--- a/pkg/apis/validation/validation_test.go
+++ b/pkg/apis/validation/validation_test.go
@@ -27,11 +27,6 @@ import (
 )
 
 func Test_ValidateAttributes(t *testing.T) {
-	type vaT struct {
-		attr     map[string]string
-		expError error
-	}
-
 	var literalSubject = "CN=${POD_NAME}.${POD_NAMESPACE}.svc.cluster.local,OU=0:${POD_NAME}\\;1:${POD_NAMESPACE}\\;2:my-region\\;4:unittest,O=foo.bar.com"
 
 	tests := map[string]struct {

--- a/pkg/requestgen/generator.go
+++ b/pkg/requestgen/generator.go
@@ -64,7 +64,11 @@ func RequestForMetadata(meta metadata.Metadata) (*manager.CertificateRequestBund
 		if err != nil {
 			return nil, fmt.Errorf("%q: %w", csiapi.LiteralSubjectKey, err)
 		}
-		request.RawSubject, err = cmpki.ParseSubjectStringToRawDerBytes(lSubjStr)
+		rdnSequence, err := cmpki.UnmarshalSubjectStringToRDNSequence(lSubjStr)
+		if err != nil {
+			return nil, fmt.Errorf("%q: %w", csiapi.LiteralSubjectKey, err)
+		}
+		request.RawSubject, err = cmpki.MarshalRDNSequenceToRawDERBytes(rdnSequence)
 		if err != nil {
 			return nil, fmt.Errorf("%q: %w", csiapi.LiteralSubjectKey, err)
 		}

--- a/pkg/requestgen/generator.go
+++ b/pkg/requestgen/generator.go
@@ -29,6 +29,7 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmutil "github.com/cert-manager/cert-manager/pkg/util"
 	cmpki "github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/csi-lib/manager"
 	"github.com/cert-manager/csi-lib/metadata"
@@ -95,7 +96,10 @@ func RequestForMetadata(meta metadata.Metadata) (*manager.CertificateRequestBund
 				if err != nil {
 					return nil, fmt.Errorf("%q: %w", v, err)
 				}
-				*k = strings.Split(e, ",")
+				*k, err = cmutil.SplitWithEscapeCSV(e)
+				if err != nil {
+					return nil, fmt.Errorf("%q: %w", v, err)
+				}
 			}
 		}
 	}

--- a/pkg/requestgen/generator.go
+++ b/pkg/requestgen/generator.go
@@ -29,6 +29,7 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmpki "github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/csi-lib/manager"
 	"github.com/cert-manager/csi-lib/metadata"
 
@@ -57,21 +58,54 @@ func RequestForMetadata(meta metadata.Metadata) (*manager.CertificateRequestBund
 		}
 	}
 
-	commonName, err := expand(meta, attrs[csiapi.CommonNameKey])
-	if err != nil {
-		return nil, fmt.Errorf("%q: %w", csiapi.CommonNameKey, err)
+	var request = &x509.CertificateRequest{}
+	if lSubjStr, ok := attrs[csiapi.LiteralSubjectKey]; ok && len(lSubjStr) > 0 {
+		lSubjStr, err = expand(meta, lSubjStr)
+		if err != nil {
+			return nil, fmt.Errorf("%q: %w", csiapi.LiteralSubjectKey, err)
+		}
+		request.RawSubject, err = cmpki.ParseSubjectStringToRawDerBytes(lSubjStr)
+		if err != nil {
+			return nil, fmt.Errorf("%q: %w", csiapi.LiteralSubjectKey, err)
+		}
+	} else {
+		request.Subject = pkix.Name{}
+		request.Subject.CommonName, err = expand(meta, attrs[csiapi.CommonNameKey])
+		if err != nil {
+			return nil, fmt.Errorf("%q: %w", csiapi.CommonNameKey, err)
+		}
+		if len(attrs[csiapi.SerialNumberKey]) > 0 {
+			request.Subject.SerialNumber = attrs[csiapi.SerialNumberKey]
+		}
+		for k, v := range map[*[]string]string{
+			&request.Subject.Organization:       csiapi.OrganizationsKey,
+			&request.Subject.OrganizationalUnit: csiapi.OrganizationalUnitsKey,
+			&request.Subject.Country:            csiapi.CountriesKey,
+			&request.Subject.Province:           csiapi.ProvincesKey,
+			&request.Subject.Locality:           csiapi.LocalitiesKey,
+			&request.Subject.StreetAddress:      csiapi.StreetAddressesKey,
+			&request.Subject.PostalCode:         csiapi.PostalCodesKey,
+		} {
+			if len(attrs[v]) > 0 {
+				var e, err = expand(meta, attrs[v])
+				if err != nil {
+					return nil, fmt.Errorf("%q: %w", v, err)
+				}
+				*k = strings.Split(e, ",")
+			}
+		}
 	}
-	dns, err := parseDNSNames(meta, attrs[csiapi.DNSNamesKey])
+	request.DNSNames, err = parseDNSNames(meta, attrs[csiapi.DNSNamesKey])
 	if err != nil {
 		return nil, fmt.Errorf("%q: %w", csiapi.DNSNamesKey, err)
 	}
-	uris, err := parseURIs(meta, attrs[csiapi.URISANsKey])
-	if err != nil {
-		return nil, fmt.Errorf("%q: %w", csiapi.URISANsKey, err)
-	}
-	ips, err := parseIPAddresses(attrs[csiapi.IPSANsKey])
+	request.IPAddresses, err = parseIPAddresses(attrs[csiapi.IPSANsKey])
 	if err != nil {
 		return nil, fmt.Errorf("%q: %w", csiapi.IPSANsKey, err)
+	}
+	request.URIs, err = parseURIs(meta, attrs[csiapi.URISANsKey])
+	if err != nil {
+		return nil, fmt.Errorf("%q: %w", csiapi.URISANsKey, err)
 	}
 
 	annotations := make(map[string]string)
@@ -88,14 +122,7 @@ func RequestForMetadata(meta metadata.Metadata) (*manager.CertificateRequestBund
 	}
 
 	return &manager.CertificateRequestBundle{
-		Request: &x509.CertificateRequest{
-			Subject: pkix.Name{
-				CommonName: commonName,
-			},
-			DNSNames:    dns,
-			IPAddresses: ips,
-			URIs:        uris,
-		},
+		Request:   request,
 		IsCA:      strings.ToLower(attrs[csiapi.IsCAKey]) == "true",
 		Namespace: attrs[csiapi.K8sVolumeContextKeyPodNamespace],
 		Duration:  duration,

--- a/pkg/requestgen/generator_test.go
+++ b/pkg/requestgen/generator_test.go
@@ -56,7 +56,12 @@ func Test_RequestForMetadata(t *testing.T) {
 	}
 
 	var literalSubject = "CN=my-pod.my-namespace.svc.cluster.local,OU=0:my-pod\\;1:my-namespace\\;2:my-region\\;4:unittest,O=foo.bar.com"
-	var rawLiteralSubject, err = cmpki.ParseSubjectStringToRawDerBytes(literalSubject)
+	rdnSequence, err := cmpki.UnmarshalSubjectStringToRDNSequence(literalSubject)
+	if err != nil {
+		assert.NoError(t, err)
+	}
+
+	rawLiteralSubject, err := cmpki.MarshalRDNSequenceToRawDERBytes(rdnSequence)
 	if err != nil {
 		assert.NoError(t, err)
 	}

--- a/pkg/requestgen/generator_test.go
+++ b/pkg/requestgen/generator_test.go
@@ -205,6 +205,7 @@ func Test_RequestForMetadata(t *testing.T) {
 					Group: "cert-manager.io",
 				},
 				Duration: cmapi.DefaultCertificateDuration,
+				Annotations: make(map[string]string),
 			},
 			expErr: false,
 		},

--- a/pkg/requestgen/generator_test.go
+++ b/pkg/requestgen/generator_test.go
@@ -28,12 +28,12 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-    cmpki "github.com/cert-manager/cert-manager/pkg/util/pki"
+	cmpki "github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/csi-lib/manager"
 	"github.com/cert-manager/csi-lib/metadata"
 	"github.com/stretchr/testify/assert"
-	csiapi "github.com/cert-manager/csi-driver/pkg/apis/v1alpha1"
 
+	csiapi "github.com/cert-manager/csi-driver/pkg/apis/v1alpha1"
 )
 
 func Test_RequestForMetadata(t *testing.T) {
@@ -204,7 +204,7 @@ func Test_RequestForMetadata(t *testing.T) {
 					Kind:  "Issuer",
 					Group: "cert-manager.io",
 				},
-				Duration: cmapi.DefaultCertificateDuration,
+				Duration:    cmapi.DefaultCertificateDuration,
 				Annotations: make(map[string]string),
 			},
 			expErr: false,
@@ -212,7 +212,7 @@ func Test_RequestForMetadata(t *testing.T) {
 		"a metadata with incorrect literal subject set should error": {
 			meta: baseMetadataWith(metadata.Metadata{VolumeContext: map[string]string{
 				csiapi.IssuerNameKey:     "my-issuer",
-				csiapi.LiteralSubjectKey: strings.Replace(literalSubject, ";", "&", -1),
+				csiapi.LiteralSubjectKey: strings.ReplaceAll(literalSubject, ";", "&"),
 			}}),
 			expErr: true,
 		},

--- a/pkg/requestgen/generator_test.go
+++ b/pkg/requestgen/generator_test.go
@@ -22,14 +22,18 @@ import (
 	"errors"
 	"net"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+    cmpki "github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/cert-manager/csi-lib/manager"
 	"github.com/cert-manager/csi-lib/metadata"
 	"github.com/stretchr/testify/assert"
+	csiapi "github.com/cert-manager/csi-driver/pkg/apis/v1alpha1"
+
 )
 
 func Test_RequestForMetadata(t *testing.T) {
@@ -49,6 +53,12 @@ func Test_RequestForMetadata(t *testing.T) {
 		puri, err := url.ParseRequestURI(uri)
 		assert.NoError(t, err)
 		return puri
+	}
+
+	var literalSubject = "CN=my-pod.my-namespace.svc.cluster.local,OU=0:my-pod\\;1:my-namespace\\;2:my-region\\;4:unittest,O=foo.bar.com"
+	var rawLiteralSubject, err = cmpki.ParseSubjectStringToRawDerBytes(literalSubject)
+	if err != nil {
+		assert.NoError(t, err)
 	}
 
 	tests := map[string]struct {
@@ -174,6 +184,31 @@ func Test_RequestForMetadata(t *testing.T) {
 				Annotations: make(map[string]string),
 			},
 			expErr: false,
+		},
+		"a metadata with literal subject set should be returned": {
+			meta: baseMetadataWith(metadata.Metadata{VolumeContext: map[string]string{
+				csiapi.IssuerNameKey:     "my-issuer",
+				csiapi.LiteralSubjectKey: literalSubject,
+			}}),
+			expRequest: &manager.CertificateRequestBundle{
+				Request:   &x509.CertificateRequest{RawSubject: rawLiteralSubject},
+				Usages:    cmapi.DefaultKeyUsages(),
+				Namespace: "my-namespace",
+				IssuerRef: cmmeta.ObjectReference{
+					Name:  "my-issuer",
+					Kind:  "Issuer",
+					Group: "cert-manager.io",
+				},
+				Duration: cmapi.DefaultCertificateDuration,
+			},
+			expErr: false,
+		},
+		"a metadata with incorrect literal subject set should error": {
+			meta: baseMetadataWith(metadata.Metadata{VolumeContext: map[string]string{
+				csiapi.IssuerNameKey:     "my-issuer",
+				csiapi.LiteralSubjectKey: strings.Replace(literalSubject, ";", "&", -1),
+			}}),
+			expErr: true,
 		},
 	}
 


### PR DESCRIPTION
Fixes #128 

This PR is a continuation of the work in #129 

I have changed the code of the `RequestForMetadata` function to use the CSV parser instead of `strings.Split` as requested in the original PR.

Would it make sense to replace the `splitList` function with `SplitWithEscapeCSV` as well? I wasn't sure if that's wanted because that code is not from #129 but was already in there before, so I left it untouched for now.
And what else needs to be done in order to get this merged?

I successfully tested it with the following manifest:

```yaml
apiVersion: "cert-manager.io/v1"
kind: "Issuer"
metadata:
  name: "self-signed-issuer"
spec:
  selfSigned: { }
---
apiVersion: "cert-manager.io/v1"
kind: "Certificate"
metadata:
  name: "self-signed-root-cert"
spec:
  secretName: "self-signed-root-cert"
  isCA: true
  commonName: "CA Cert"
  issuerRef:
    name: "self-signed-issuer"
---
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: ca-issuer
spec:
  ca:
    secretName: "self-signed-root-cert"
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: csi-test
spec:
  selector:
    matchLabels:
      app: csi-test
  template:
    metadata:
      labels:
        app: csi-test
    spec:
      containers:
        - name: csi-test
          image: "docker.io/library/alpine:latest"
          command:
            - "/bin/sh"
            - "-c"
            - "apk add openssl && openssl x509 -noout -text -in /cert/tls.crt && sleep infinity"
          volumeMounts:
            - mountPath: "/cert"
              name: cert
      volumes:
        - name: "cert"
          csi:
              driver: "csi.cert-manager.io"
              readOnly: true
              volumeAttributes:
                csi.cert-manager.io/issuer-name: "ca-issuer"
                csi.cert-manager.io/common-name: "test-cert"
                csi.cert-manager.io/organizations: "organization"
                csi.cert-manager.io/organizationalunits: "organizationalunit"
                csi.cert-manager.io/countries: "country"
                csi.cert-manager.io/provinces: "province"
                csi.cert-manager.io/localities: "locality"
                csi.cert-manager.io/streetaddresses: "streetaddress"
                csi.cert-manager.io/postalcodes: "postalcode"
```

resulting in the following output:

```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            ab:ca:22:02:06:92:c3:27:47:aa:d2:5b:55:b2:f5:01
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: CN = CA Cert
        Validity
            Not Before: Mar 27 16:34:50 2024 GMT
            Not After : Jun 25 16:34:50 2024 GMT
        Subject: C = country, ST = province, L = locality, street = streetaddress, postalCode = postalcode, O = organization, OU = organizationalunit, CN = test-cert
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                Public-Key: (2048 bit)
                Modulus:
                    00:c7:d0:55:35:99:bc:11:39:eb:b7:11:0d:56:65:
                    02:53:b3:c6:a0:5c:6c:6b:0d:f8:b8:c2:77:99:55:
                    88:d0:b8:ca:ad:0c:83:38:fe:f6:79:df:b8:ba:d6:
                    e3:1c:a4:b1:35:65:29:ec:0b:72:94:6e:27:97:47:
                    62:6f:10:06:32:e7:e1:42:d4:cf:c1:3e:bc:69:a5:
                    12:58:7e:85:ea:61:39:86:eb:aa:1a:2d:08:f8:22:
                    02:e2:cf:91:e8:04:cf:62:10:54:9d:b3:25:02:49:
                    5f:3c:57:45:03:2f:85:c5:d0:85:32:e9:74:c3:57:
                    f6:41:37:93:c3:9e:a7:40:3b:de:42:83:ed:e3:b6:
                    d0:f4:20:c2:d3:9e:e4:cc:5c:db:65:45:c3:42:d2:
                    59:b3:28:3e:42:4e:05:20:28:3d:d0:40:b9:59:50:
                    90:5d:1f:66:d3:f5:d4:50:79:b6:01:46:50:4f:b0:
                    18:36:dc:8e:23:ff:a1:98:20:fe:9a:21:55:dd:fb:
                    4b:7a:ed:ef:80:3b:59:47:2c:31:93:ff:78:57:f1:
                    4a:a1:86:9d:38:01:cf:cc:01:dd:88:2f:86:ce:4f:
                    21:6c:a0:2f:29:47:41:ed:b2:4a:d8:d2:3f:27:49:
                    54:6d:4d:7c:ab:ed:67:6e:ba:00:b3:7c:a5:15:09:
                    07:95
                Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Authority Key Identifier: 
                41:B9:47:09:7C:34:AD:30:16:33:C3:08:2A:9A:BD:BF:6C:AB:10:DA
    Signature Algorithm: sha256WithRSAEncryption
    Signature Value:
        03:07:49:e6:6e:2e:87:5d:82:df:d4:10:f2:4d:62:33:0d:df:
        17:59:ce:ff:99:bc:40:02:8a:46:e2:71:1c:f9:0b:7a:eb:fb:
        9e:6a:df:01:e7:52:0b:82:0c:c9:a8:93:c7:a1:b2:fe:ee:a2:
        1b:80:4e:b8:a5:ac:d5:45:cb:8e:12:0a:ab:bd:76:70:3b:00:
        aa:f9:58:ed:a8:17:76:5b:64:74:a1:33:3b:d9:5d:a5:12:2f:
        c7:92:d5:90:b3:38:29:98:0e:e1:bc:6c:f8:ce:f1:2b:13:86:
        e6:1b:8c:00:9f:1f:32:62:9b:fc:a4:83:e6:21:69:56:ab:0e:
        b1:fa:ec:15:48:9d:8d:12:48:d1:8f:22:9f:ee:f8:7b:b7:e3:
        52:67:be:f8:5d:70:a3:f2:7a:ad:00:e0:14:aa:08:90:34:69:
        17:9d:4d:ee:57:06:7d:ec:12:f0:6f:32:04:60:dc:0a:ed:27:
        2b:02:98:de:0a:1e:19:d0:0d:42:8d:e7:6f:6a:3b:00:fd:16:
        91:d2:2b:76:e7:f0:51:af:ac:83:b3:a5:0b:b1:3e:fa:3d:20:
        e2:e3:4e:df:8a:7a:d8:da:8d:f8:3f:2f:e6:95:7b:c9:a3:64:
        56:26:a6:c1:95:94:de:c6:c2:c3:75:dd:be:76:66:56:50:e5:
        40:51:98:0d
```