### PR TITLE
Fix gosec issues and enable gosec linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,3 @@
-issues:
-  exclude-rules:
-    - linters:
-        - gosec
-      text: ".*"
 linters:
   # Explicitly define all enabled linters
   disable-all: true

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -40,7 +40,7 @@ const (
 
 	KeyStorePKCS12EnableKey   = "csi.cert-manager.io/pkcs12-enable"
 	KeyStorePKCS12FileKey     = "csi.cert-manager.io/pkcs12-filename"
-	KeyStorePKCS12PasswordKey = "csi.cert-manager.io/pkcs12-password"
+	KeyStorePKCS12PasswordKey = "csi.cert-manager.io/pkcs12-password" // #nosec G101: False positive, gosec thinks this is a credential.
 )
 
 const (

--- a/test/e2e/framework/helper/kubectl.go
+++ b/test/e2e/framework/helper/kubectl.go
@@ -54,7 +54,7 @@ func (k *Kubectl) Run(args ...string) error {
 		baseArgs = []string{"--namespace", k.namespace}
 	}
 	args = append(baseArgs, args...)
-	cmd := exec.Command(k.kubectl, args...)
+	cmd := exec.Command(k.kubectl, args...) // #nosec G204 -- This function is only used for tests.
 	cmd.Stdout = log.Writer
 	cmd.Stderr = log.Writer
 	return cmd.Run()

--- a/test/e2e/framework/testenv.go
+++ b/test/e2e/framework/testenv.go
@@ -60,6 +60,8 @@ VOodKC004yjh7w9aSbCCbAL0tDEnhm4Jrb8cxt7pDWbdEVUeuk9LZRQtluYBnmJU
 kQ7ALfUfUh/RUpCV4uI6sEI3NDX2YqQbOtsBD/hNaL1F85FA
 -----END CERTIFICATE-----`
 
+	// #nosec G101 -- This is a test PK, ideally we would dynamically
+	// generate this pair, but this should not be a security risk.
 	rootKey = `-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAz5DYA7iEBFq/SrCOTsjiYSHlHbTUdLyzselos5cE2++Huon3
 InPqMupiDoS8/Qr9srnoKnah7aKB3sY7GlXdg85zcIbQIKocymsRy/GPbEEpfTRG


### PR DESCRIPTION
Checked all found issues and applied fixes/ #nosec statements.
Now that all issues are fixed, I removed the gosec linter from the ignored section so future issues will be detected.