### PR TITLE
Helm: set linux nodeSelector by default

### DIFF
--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -231,15 +231,11 @@ resources:
 #### **nodeSelector** ~ `object`
 > Default value:
 > ```yaml
-> {}
+> kubernetes.io/os: linux
 > ```
 
-Kubernetes node selector: node labels for pod assignment. For example, use this to allow scheduling of DaemonSet on linux nodes only:
+Kubernetes node selector: node labels for pod assignment.
 
-```yaml
-nodeSelector:
-  kubernetes.io/os: linux
-```
 #### **affinity** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -279,8 +279,10 @@
       "type": "string"
     },
     "helm-values.nodeSelector": {
-      "default": {},
-      "description": "Kubernetes node selector: node labels for pod assignment. For example, use this to allow scheduling of DaemonSet on linux nodes only:\nnodeSelector:\n  kubernetes.io/os: linux",
+      "default": {
+        "kubernetes.io/os": "linux"
+      },
+      "description": "Kubernetes node selector: node labels for pod assignment.",
       "type": "object"
     },
     "helm-values.podAnnotations": {

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -125,10 +125,9 @@ podLabels: {}
 resources: {}
 
 # Kubernetes node selector: node labels for pod assignment.
-# For example, use this to allow scheduling of DaemonSet on linux nodes only:
-#  nodeSelector:
-#    kubernetes.io/os: linux
-nodeSelector: {}
+# +docs:property=nodeSelector
+nodeSelector:
+  kubernetes.io/os: linux
 
 # Kubernetes affinity: constraints for pod assignment.
 # 


### PR DESCRIPTION
Similar to cert-manager and csi-driver-spiffe, set the `nodeSelector` to `kubernetes.io/os: linux` by default.