### PR TITLE
Updated OWNERS file to grant current c-m maintainers access

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,4 @@
 approvers:
-- munnerz
-- joshvanl
-- wallrj
-- jakexks
-- maelvls
-- irbekrm
-- sgtcodfish
-- inteon
+- cm-maintainers
 reviewers:
-- munnerz
-- joshvanl
-- wallrj
-- jakexks
-- maelvls
-- irbekrm
-- sgtcodfish
-- inteon
-- thatsmrtalbot
+- cm-maintainers


### PR DESCRIPTION
My LGTM didn't count on https://github.com/cert-manager/csi-driver/pull/449 (example), and I want to fix this.