### PR TITLE
Allow setting hostNetwork values in helm chart

### DIFF
--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -438,6 +438,17 @@ tolerations:
 > ```
 
 Optional priority class to be used for the csi-driver pods.
+#### **hostNetwork** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Configure the host network setting for the csi-driver pods. SECURITY WARNING: When set to true, pods will use the host's network namespace, which grants access to all host network interfaces and allows binding to any port. Ensure this aligns with your security requirements before enabling.  
+  
+Use case: In some CNI configurations (e.g., Cilium), enabling hostNetwork allows the CSI driver to start before the CNI is ready, reducing pod scheduling delays.  
+  
+Note: When using hostNetwork, ensure ports for liveness probe and metrics (if enabled) do not conflict with other services on your nodes.
 #### **openshift.securityContextConstraint.enabled** ~ `boolean,string,null`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -38,6 +38,7 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
       containers:
 
         - name: node-driver-registrar

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -18,6 +18,9 @@
         "global": {
           "$ref": "#/$defs/helm-values.global"
         },
+        "hostNetwork": {
+          "$ref": "#/$defs/helm-values.hostNetwork"
+        },
         "image": {
           "$ref": "#/$defs/helm-values.image"
         },
@@ -152,6 +155,11 @@
     },
     "helm-values.global": {
       "description": "Global values shared across all (sub)charts"
+    },
+    "helm-values.hostNetwork": {
+      "default": false,
+      "description": "Configure the host network setting for the csi-driver pods.\nIf set to true, the pod will use the host network namespace.",
+      "type": "boolean"
     },
     "helm-values.image": {
       "additionalProperties": false,

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -158,7 +158,7 @@
     },
     "helm-values.hostNetwork": {
       "default": false,
-      "description": "Configure the host network setting for the csi-driver pods.\nIf set to true, the pod will use the host network namespace.",
+      "description": "Configure the host network setting for the csi-driver pods. SECURITY WARNING: When set to true, pods will use the host's network namespace, which grants access to all host network interfaces and allows binding to any port. Ensure this aligns with your security requirements before enabling.\n\nUse case: In some CNI configurations (e.g., Cilium), enabling hostNetwork allows the CSI driver to start before the CNI is ready, reducing pod scheduling delays.\n\nNote: When using hostNetwork, ensure ports for liveness probe and metrics (if enabled) do not conflict with other services on your nodes.",
       "type": "boolean"
     },
     "helm-values.image": {

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -276,7 +276,15 @@ tolerations: []
 priorityClassName: ""
 
 # Configure the host network setting for the csi-driver pods.
-# If set to true, the pod will use the host network namespace.
+# SECURITY WARNING: When set to true, pods will use the host's network namespace,
+# which grants access to all host network interfaces and allows binding to any port.
+# Ensure this aligns with your security requirements before enabling.
+#
+# Use case: In some CNI configurations (e.g., Cilium), enabling hostNetwork allows
+# the CSI driver to start before the CNI is ready, reducing pod scheduling delays.
+#
+# Note: When using hostNetwork, ensure ports for liveness probe and metrics (if enabled)
+# do not conflict with other services on your nodes.
 hostNetwork: false
 
 openshift:

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -275,6 +275,10 @@ tolerations: []
 # Optional priority class to be used for the csi-driver pods.
 priorityClassName: ""
 
+# Configure the host network setting for the csi-driver pods.
+# If set to true, the pod will use the host network namespace.
+hostNetwork: false
+
 openshift:
   securityContextConstraint:
     # Include RBAC to allow the DaemonSet to "use" the specified


### PR DESCRIPTION
We're looking into some performance improvements with pod scheduling time and want to use hostNetworking with the csi driver. Currently the helm chart doesn't support enabling it.

Here's the current flow:
1) node created
2) node cni pod (cilium) Readiness check passed
3) pod using csi driver scheduled & pulled
4) csi driver scheduled & pulled
5) pod emits this error:
```
MountVolume.SetUp failed for volume "tls" : kubernetes.io/csi: mounter.SetUpAt failed to get CSI client: driver name csi.cert-manager.io not found in the list of registered CSI drivers
```

6) cert manager csi driver Readiness check passed
7) pod created successfully. 

by using hostNetworking we can skip the dependency on the CNI and avoid this MountVolume.SetUp error in most cases by allowing the pod to start before cilium gets ready.