### PR TITLE
feat(pki): add pkcs12-password-file (auto-mounts password)

### DIFF
--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -53,6 +53,10 @@ const (
 	KeyStorePKCS12EnableKey   = "csi.cert-manager.io/pkcs12-enable"
 	KeyStorePKCS12FileKey     = "csi.cert-manager.io/pkcs12-filename"
 	KeyStorePKCS12PasswordKey = "csi.cert-manager.io/pkcs12-password" // #nosec G101: False positive, gosec thinks this is a credential.
+	// KeyStorePKCS12PasswordFileKey is an optional filename that, when set,
+	// will cause the driver to write the PKCS12 password to a separate file
+	// within the volume. The value is the filename to write (e.g. "pkcs12.pw").
+	KeyStorePKCS12PasswordFileKey = "csi.cert-manager.io/pkcs12-password-file"
 )
 
 const (

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -53,9 +53,10 @@ const (
 	KeyStorePKCS12EnableKey   = "csi.cert-manager.io/pkcs12-enable"
 	KeyStorePKCS12FileKey     = "csi.cert-manager.io/pkcs12-filename"
 	KeyStorePKCS12PasswordKey = "csi.cert-manager.io/pkcs12-password" // #nosec G101: False positive, gosec thinks this is a credential.
-	// KeyStorePKCS12PasswordFileKey is an optional filename that, when set,
-	// will cause the driver to write the PKCS12 password to a separate file
-	// within the volume. The value is the filename to write (e.g. "pkcs12.pw").
+	// KeyStorePKCS12PasswordFileKey is an optional path to a file containing
+	// the PKCS12 password. The driver will read the password from this file
+	// instead of using the inline csi.cert-manager.io/pkcs12-password value.
+	// Example: "/etc/secrets/pkcs12.pass"
 	KeyStorePKCS12PasswordFileKey = "csi.cert-manager.io/pkcs12-password-file"
 )
 

--- a/pkg/apis/validation/validation.go
+++ b/pkg/apis/validation/validation.go
@@ -52,6 +52,7 @@ func ValidateAttributes(attr map[string]string) field.ErrorList {
 	el = append(el, filename(path.Child(csiapi.CertFileKey), attr[csiapi.CertFileKey])...)
 	el = append(el, filename(path.Child(csiapi.KeyFileKey), attr[csiapi.KeyFileKey])...)
 	el = append(el, filename(path.Child(csiapi.KeyStorePKCS12FileKey), attr[csiapi.KeyStorePKCS12FileKey])...)
+	el = append(el, filename(path.Child(csiapi.KeyStorePKCS12PasswordFileKey), attr[csiapi.KeyStorePKCS12PasswordFileKey])...)
 
 	el = append(el, durationParse(path.Child(csiapi.RenewBeforeKey), attr[csiapi.RenewBeforeKey])...)
 	el = append(el, boolValue(path.Child(csiapi.ReusePrivateKey), attr[csiapi.ReusePrivateKey])...)
@@ -61,10 +62,11 @@ func ValidateAttributes(attr map[string]string) field.ErrorList {
 	el = append(el, pkcs12Values(path, attr)...)
 
 	el = append(el, uniqueFilePaths(path, map[string]string{
-		csiapi.CAFileKey:             attr[csiapi.CAFileKey],
-		csiapi.CertFileKey:           attr[csiapi.CertFileKey],
-		csiapi.KeyFileKey:            attr[csiapi.KeyFileKey],
-		csiapi.KeyStorePKCS12FileKey: attr[csiapi.KeyStorePKCS12FileKey],
+		csiapi.CAFileKey:                         attr[csiapi.CAFileKey],
+		csiapi.CertFileKey:                       attr[csiapi.CertFileKey],
+		csiapi.KeyFileKey:                        attr[csiapi.KeyFileKey],
+		csiapi.KeyStorePKCS12FileKey:             attr[csiapi.KeyStorePKCS12FileKey],
+		csiapi.KeyStorePKCS12PasswordFileKey:     attr[csiapi.KeyStorePKCS12PasswordFileKey],
 	})...)
 
 	// If there are errors, then return not approved and the aggregated errors.
@@ -188,7 +190,7 @@ func filename(path *field.Path, filename string) field.ErrorList {
 	}
 
 	if strings.Contains(filename, "/") {
-		el = append(el, field.Invalid(path, filename, "filename must not include '/'"))
+		el = append(el, field.Invalid(path, filename, "filename must not include '/'") )
 	}
 
 	if len(filename) > 255 {
@@ -236,11 +238,26 @@ func pkcs12Values(path *field.Path, attr map[string]string) field.ErrorList {
 	var el field.ErrorList
 
 	if enable := attr[csiapi.KeyStorePKCS12EnableKey]; len(enable) > 0 {
+		// When PKCS12 is enabled, a PKCS12 file must be written. An explicit
+		// password via csi.cert-manager.io/pkcs12-password is required. Optionally
+		// csi.cert-manager.io/pkcs12-password-file may be provided to write that
+		// password to a separate file within the volume. The attributes are
+		// mutually exclusive: the user must provide exactly one of the password or
+		// password-file attributes.
 		if file := attr[csiapi.KeyStorePKCS12FileKey]; len(file) == 0 {
 			el = append(el, field.Required(path.Child(csiapi.KeyStorePKCS12FileKey), "required attribute when PKCS12 KeyStore is enabled"))
 		}
-		if password := attr[csiapi.KeyStorePKCS12PasswordKey]; len(password) == 0 {
-			el = append(el, field.Required(path.Child(csiapi.KeyStorePKCS12PasswordKey), "required attribute when PKCS12 KeyStore is enabled"))
+
+		password := attr[csiapi.KeyStorePKCS12PasswordKey]
+		passwordFile := attr[csiapi.KeyStorePKCS12PasswordFileKey]
+
+		// Require exactly one of password or password-file when PKCS12 is enabled.
+		if len(password) == 0 && len(passwordFile) == 0 {
+			el = append(el, field.Required(path.Child(csiapi.KeyStorePKCS12PasswordKey), "one of pkcs12-password or pkcs12-password-file is required when PKCS12 KeyStore is enabled"))
+		}
+
+		if len(password) > 0 && len(passwordFile) > 0 {
+			el = append(el, field.Invalid(path.Child(csiapi.KeyStorePKCS12PasswordFileKey), passwordFile, "cannot specify both pkcs12-password and pkcs12-password-file"))
 		}
 
 		switch enable {
@@ -259,6 +276,11 @@ func pkcs12Values(path *field.Path, attr map[string]string) field.ErrorList {
 
 		if password, ok := attr[csiapi.KeyStorePKCS12PasswordKey]; ok {
 			el = append(el, field.Invalid(path.Child(csiapi.KeyStorePKCS12PasswordKey), password,
+				fmt.Sprintf("cannot use attribute without %q set to %q or %q", csiapi.KeyStorePKCS12EnableKey, "true", "false")))
+		}
+
+		if passwordFile := attr[csiapi.KeyStorePKCS12PasswordFileKey]; len(passwordFile) > 0 {
+			el = append(el, field.Invalid(path.Child(csiapi.KeyStorePKCS12PasswordFileKey), passwordFile,
 				fmt.Sprintf("cannot use attribute without %q set to %q or %q", csiapi.KeyStorePKCS12EnableKey, "true", "false")))
 		}
 	}

--- a/pkg/keystore/pkcs12/pkcs12.go
+++ b/pkg/keystore/pkcs12/pkcs12.go
@@ -44,6 +44,22 @@ func Handle(attributes map[string]string, files map[string][]byte, pk crypto.Pri
 	// Write PKCS12 file to the file store.
 	files[attributes[csiapi.KeyStorePKCS12FileKey]] = pfx
 
+	// If a separate password filename is requested, write the password to that
+	// filename so consumers can read the password from the volume.
+	// The password-file attribute is optional. Validation requires that the
+	// password attribute itself is present when PKCS12 is enabled; when a
+	// filename is requested we write the provided password into that file.
+	passwordFile := attributes[csiapi.KeyStorePKCS12PasswordFileKey]
+	if len(passwordFile) > 0 {
+		// Only write the password file when a filename is requested. Validation
+		// will prevent an empty password when PKCS12 is enabled; still perform a
+		// defensive check to avoid writing an empty file at runtime.
+		pwd := attributes[csiapi.KeyStorePKCS12PasswordKey]
+		if len(pwd) > 0 {
+			files[passwordFile] = []byte(pwd)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Dual-purpose paramete **csi.cert-manager.io/pkcs12-password-file**:

1. **Replaces** inline `pkcs12-password`.
2. **Auto-mounts** password file in volume.

Example:

```yaml
csi.cert-manager.io/pkcs12-password-file: "pkcs12.pass"
```

CSI creates files

/volume/
├── server.p12      #  PKCS12 keystore  
└── pkcs12.pass     # password (from inline attr)