### PR TITLE
feat: add --continue-on-not-ready flag to CSI driver (disabled by default)

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -82,10 +82,11 @@ func NewCommand(ctx context.Context) *cobra.Command {
 
 			mngrlog := opts.Logr.WithName("manager")
 			d, err := driver.New(ctx, opts.Endpoint, opts.Logr.WithName("driver"), driver.Options{
-				DriverName:    opts.DriverName,
-				DriverVersion: version.AppVersion,
-				NodeID:        opts.NodeID,
-				Store:         store,
+				DriverName:         opts.DriverName,
+				DriverVersion:      version.AppVersion,
+				NodeID:             opts.NodeID,
+				Store:              store,
+				ContinueOnNotReady: opts.ContinueOnNotReady,
 				Manager: manager.NewManagerOrDie(manager.Options{
 					Client:             opts.CMClient,
 					ClientForMetadata:  clientForMeta,

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -60,6 +60,12 @@ type Options struct {
 	// to be defined on the CSIDriver manifest.
 	UseTokenRequest bool
 
+	// ContinueOnNotReady allows NodePublishVolume to succeed even when the
+	// driver is not yet ready to create certificate requests. The volume is mounted
+	// immediately and certificate issuance is retried asynchronously. Pods MUST
+	// tolerate the absence of certificate data at startup (e.g. via init container).
+	ContinueOnNotReady bool
+
 	// Logr is the shared base logger.
 	Logr logr.Logger
 
@@ -160,4 +166,9 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", "0",
 		"TCP address for exposing HTTP Prometheus metrics which will be served on the HTTP path '/metrics'. "+
 			`The value "0" will disable exposing metrics.`)
+
+	fs.BoolVar(&o.ContinueOnNotReady, "continue-on-not-ready", false,
+		"Continue mounting the volume even if driver is not ready to create certificate request yet. "+
+			"Useful in deferring certificate issuance until after pod initialization or until after sandbox creation. "+
+			"Pods MUST handle the absence of certificate data at startup (e.g. via init container).")
 }

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -327,6 +327,13 @@ Name of the driver to be registered with Kubernetes.
 > ```
 
 If enabled, this uses a CSI token request for creating. CertificateRequests. CertificateRequests are created by mounting the pod's service accounts.
+#### **app.driver.continueOnNotReady** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+If enabled, allows NodePublishVolume to succeed even when the driver is not yet ready to create certificate request. The volume is mounted immediately and certificate issuance is retried asynchronously.
 #### **app.driver.csiDataDir** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -95,6 +95,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --data-root=csi-data-dir
             - --use-token-request={{ .Values.app.driver.useTokenRequest }}
+            - --continue-on-not-ready={{ .Values.app.driver.continueOnNotReady }}
 {{- if .Values.metrics.enabled }}
             - --metrics-bind-address=:{{ .Values.metrics.port }}
 {{- else }}

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -89,6 +89,9 @@
     "helm-values.app.driver": {
       "additionalProperties": false,
       "properties": {
+        "continueOnNotReady": {
+          "$ref": "#/$defs/helm-values.app.driver.continueOnNotReady"
+        },
         "csiDataDir": {
           "$ref": "#/$defs/helm-values.app.driver.csiDataDir"
         },
@@ -100,6 +103,11 @@
         }
       },
       "type": "object"
+    },
+    "helm-values.app.driver.continueOnNotReady": {
+      "default": false,
+      "description": "If enabled, allows NodePublishVolume to succeed even when the driver is not yet ready to create certificate request. The volume is mounted immediately and certificate issuance is retried asynchronously.",
+      "type": "boolean"
     },
     "helm-values.app.driver.csiDataDir": {
       "default": "/tmp/cert-manager-csi-driver",

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -216,6 +216,10 @@ app:
     # CertificateRequests. CertificateRequests are created by mounting the
     # pod's service accounts.
     useTokenRequest: false
+    # If enabled, allows NodePublishVolume to succeed even when the
+    # driver is not yet ready to create certificate request. The volume is mounted
+    # immediately and certificate issuance is retried asynchronously.
+    continueOnNotReady: false
     # Configures the hostPath directory that the driver writes and mounts volumes from.
     csiDataDir: /tmp/cert-manager-csi-driver
   # Options for the liveness container.


### PR DESCRIPTION
Exposes the existing `ContinueOnNotReady` option from [csi-lib](https://github.com/cert-manager/csi-lib/blob/e9b33fffc3408ef368e9a437d619e631b4af33f7/driver/driver.go#L65) (already supported since v0.10.0) as a CLI flag and Helm value.

When enabled, NodePublishVolume succeeds immediately and certificate issuance is retried asynchronously — useful for workloads where the pod IP isn't available at mount time (e.g. IPAM-assigned addresses).

*This is a non-breaking change:*
  - The flag defaults to false, preserving current behaviour exactly
  - No dependency updates required
  - No existing behaviour is modified
