### PR TITLE
feat: add --kube-api-qps and --kube-api-burst flags to CSI driver

### DIFF
--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -80,6 +80,14 @@ type Options struct {
 	// which will be served on the HTTP path '/metrics'. The value "0" will
 	// disable exposing metrics.
 	MetricsBindAddress string
+
+	// KubernetesAPIQPS is the maximum queries-per-second of requests sent
+	// to the Kubernetes apiserver.
+	KubernetesAPIQPS float32
+
+	// KubernetesAPIBurst is the maximum burst queries-per-second of requests
+	// sent to the Kubernetes apiserver.
+	KubernetesAPIBurst int
 }
 
 func New() *Options {
@@ -104,6 +112,9 @@ func (o *Options) Complete() error {
 	if err != nil {
 		return fmt.Errorf("failed to build kubernetes rest config: %s", err)
 	}
+
+	o.RestConfig.QPS = o.KubernetesAPIQPS
+	o.RestConfig.Burst = o.KubernetesAPIBurst
 
 	o.CMClient, err = cmclient.NewForConfig(o.RestConfig)
 	if err != nil {
@@ -171,4 +182,7 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 		"Continue mounting the volume even if driver is not ready to create certificate request yet. "+
 			"Useful in deferring certificate issuance until after pod initialization or until after sandbox creation. "+
 			"Pods MUST handle the absence of certificate data at startup (e.g. via init container).")
+
+	fs.Float32Var(&o.KubernetesAPIQPS, "kube-api-qps", 0, "indicates the maximum queries-per-second requests to the Kubernetes apiserver")
+	fs.IntVar(&o.KubernetesAPIBurst, "kube-api-burst", 0, "the maximum burst queries-per-second of requests sent to the Kubernetes apiserver")
 }

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -340,14 +340,16 @@ If enabled, allows NodePublishVolume to succeed even when the driver is not yet 
 > 0
 > ```
 
-Indicates the maximum queries-per-second requests to the Kubernetes apiserver. A value of 0 uses client-go's default.
+Indicates the maximum queries-per-second requests to the Kubernetes apiserver.  
+A value of 0 uses client-go's default.
 #### **app.driver.kubernetesAPIBurst** ~ `number`
 > Default value:
 > ```yaml
 > 0
 > ```
 
-The maximum burst queries-per-second of requests sent to the Kubernetes apiserver. A value of 0 uses client-go's default.
+The maximum burst queries-per-second of requests sent to the Kubernetes apiserver.  
+A value of 0 uses client-go's default.
 #### **app.driver.csiDataDir** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -334,6 +334,20 @@ If enabled, this uses a CSI token request for creating. CertificateRequests. Cer
 > ```
 
 If enabled, allows NodePublishVolume to succeed even when the driver is not yet ready to create certificate request. The volume is mounted immediately and certificate issuance is retried asynchronously.
+#### **app.driver.kubernetesAPIQPS** ~ `number`
+> Default value:
+> ```yaml
+> 0
+> ```
+
+Indicates the maximum queries-per-second requests to the Kubernetes apiserver. A value of 0 uses client-go's default.
+#### **app.driver.kubernetesAPIBurst** ~ `number`
+> Default value:
+> ```yaml
+> 0
+> ```
+
+The maximum burst queries-per-second of requests sent to the Kubernetes apiserver. A value of 0 uses client-go's default.
 #### **app.driver.csiDataDir** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -96,6 +96,8 @@ spec:
             - --data-root=csi-data-dir
             - --use-token-request={{ .Values.app.driver.useTokenRequest }}
             - --continue-on-not-ready={{ .Values.app.driver.continueOnNotReady }}
+            - --kube-api-qps={{ .Values.app.driver.kubernetesAPIQPS }}
+            - --kube-api-burst={{ .Values.app.driver.kubernetesAPIBurst }}
 {{- if .Values.metrics.enabled }}
             - --metrics-bind-address=:{{ .Values.metrics.port }}
 {{- else }}

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -95,6 +95,12 @@
         "csiDataDir": {
           "$ref": "#/$defs/helm-values.app.driver.csiDataDir"
         },
+        "kubernetesAPIBurst": {
+          "$ref": "#/$defs/helm-values.app.driver.kubernetesAPIBurst"
+        },
+        "kubernetesAPIQPS": {
+          "$ref": "#/$defs/helm-values.app.driver.kubernetesAPIQPS"
+        },
         "name": {
           "$ref": "#/$defs/helm-values.app.driver.name"
         },
@@ -113,6 +119,16 @@
       "default": "/tmp/cert-manager-csi-driver",
       "description": "Configures the hostPath directory that the driver writes and mounts volumes from.",
       "type": "string"
+    },
+    "helm-values.app.driver.kubernetesAPIBurst": {
+      "default": 0,
+      "description": "The maximum burst queries-per-second of requests sent to the Kubernetes apiserver. A value of 0 uses client-go's default.",
+      "type": "number"
+    },
+    "helm-values.app.driver.kubernetesAPIQPS": {
+      "default": 0,
+      "description": "Indicates the maximum queries-per-second requests to the Kubernetes apiserver. A value of 0 uses client-go's default.",
+      "type": "number"
     },
     "helm-values.app.driver.name": {
       "default": "csi.cert-manager.io",

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -122,12 +122,12 @@
     },
     "helm-values.app.driver.kubernetesAPIBurst": {
       "default": 0,
-      "description": "The maximum burst queries-per-second of requests sent to the Kubernetes apiserver. A value of 0 uses client-go's default.",
+      "description": "The maximum burst queries-per-second of requests sent to the Kubernetes apiserver.\nA value of 0 uses client-go's default.",
       "type": "number"
     },
     "helm-values.app.driver.kubernetesAPIQPS": {
       "default": 0,
-      "description": "Indicates the maximum queries-per-second requests to the Kubernetes apiserver. A value of 0 uses client-go's default.",
+      "description": "Indicates the maximum queries-per-second requests to the Kubernetes apiserver.\nA value of 0 uses client-go's default.",
       "type": "number"
     },
     "helm-values.app.driver.name": {

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -221,10 +221,10 @@ app:
     # immediately and certificate issuance is retried asynchronously.
     continueOnNotReady: false
     # Indicates the maximum queries-per-second requests to the Kubernetes apiserver.
-    # A value of 0 uses client-go's default (currently 5).
+    # A value of 0 uses client-go's default.
     kubernetesAPIQPS: 0
     # The maximum burst queries-per-second of requests sent to the Kubernetes apiserver.
-    # A value of 0 uses client-go's default (currently 10).
+    # A value of 0 uses client-go's default.
     kubernetesAPIBurst: 0
     # Configures the hostPath directory that the driver writes and mounts volumes from.
     csiDataDir: /tmp/cert-manager-csi-driver

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -220,6 +220,12 @@ app:
     # driver is not yet ready to create certificate request. The volume is mounted
     # immediately and certificate issuance is retried asynchronously.
     continueOnNotReady: false
+    # Indicates the maximum queries-per-second requests to the Kubernetes apiserver.
+    # A value of 0 uses client-go's default (currently 5).
+    kubernetesAPIQPS: 0
+    # The maximum burst queries-per-second of requests sent to the Kubernetes apiserver.
+    # A value of 0 uses client-go's default (currently 10).
+    kubernetesAPIBurst: 0
     # Configures the hostPath directory that the driver writes and mounts volumes from.
     csiDataDir: /tmp/cert-manager-csi-driver
   # Options for the liveness container.


### PR DESCRIPTION
Adds configurable Kubernetes API client rate limiting to the CSI driver, matching the flags already available in the controller.

Two new CLI flags are introduced:
- `--kube-api-qps` — maximum queries-per-second to the Kubernetes apiserver
- `--kube-api-burst` — maximum burst queries-per-second to the Kubernetes apiserver

Both default to `0`, which preserves client-go's built-in defaults (5 QPS / 10 burst).

Helm chart changes:
- `app.driver.kubernetesAPIQPS` and `app.driver.kubernetesAPIBurst` values added to `values.yaml`
- Daemonset template updated to pass the flags
- `values.schema.json` and `README.md` updated accordingly