### PR TITLE
fix: allow disabling PKCS12 without password

### DIFF
--- a/pkg/apis/defaults/defaults.go
+++ b/pkg/apis/defaults/defaults.go
@@ -107,7 +107,7 @@ func setDefaultIfEmpty(attr map[string]string, k, v string) {
 // in the attributes at all. If the other attributes are present, then a
 // validation error will be picked up by validation.
 func setDefaultKeyStorePKCS12(attr map[string]string) {
-	if _, ok := attr[csiapi.KeyStorePKCS12EnableKey]; ok {
+	if attr[csiapi.KeyStorePKCS12EnableKey] == "true" {
 		setDefaultIfEmpty(attr, csiapi.KeyStorePKCS12FileKey, "keystore.p12")
 	}
 }

--- a/pkg/apis/defaults/defaults_test.go
+++ b/pkg/apis/defaults/defaults_test.go
@@ -31,13 +31,29 @@ func Test_pkcs12Values(t *testing.T) {
 			input:     map[string]string{},
 			expOutput: map[string]string{},
 		},
-		"if PKCS12 enable attribute present, expect PKCS12 attributes present": {
+		"if PKCS12 is enabled, expect PKCS12 file attribute present": {
+			input: map[string]string{
+				"csi.cert-manager.io/pkcs12-enable": "true",
+			},
+			expOutput: map[string]string{
+				"csi.cert-manager.io/pkcs12-enable":   "true",
+				"csi.cert-manager.io/pkcs12-filename": "keystore.p12",
+			},
+		},
+		"if PKCS12 is disabled, expect no PKCS12 file attribute": {
+			input: map[string]string{
+				"csi.cert-manager.io/pkcs12-enable": "false",
+			},
+			expOutput: map[string]string{
+				"csi.cert-manager.io/pkcs12-enable": "false",
+			},
+		},
+		"if PKCS12 enable attribute is invalid, expect no PKCS12 file attribute": {
 			input: map[string]string{
 				"csi.cert-manager.io/pkcs12-enable": "foo",
 			},
 			expOutput: map[string]string{
-				"csi.cert-manager.io/pkcs12-enable":   "foo",
-				"csi.cert-manager.io/pkcs12-filename": "keystore.p12",
+				"csi.cert-manager.io/pkcs12-enable": "foo",
 			},
 		},
 	}

--- a/pkg/apis/validation/validation.go
+++ b/pkg/apis/validation/validation.go
@@ -236,19 +236,18 @@ func pkcs12Values(path *field.Path, attr map[string]string) field.ErrorList {
 	var el field.ErrorList
 
 	if enable := attr[csiapi.KeyStorePKCS12EnableKey]; len(enable) > 0 {
-		if file := attr[csiapi.KeyStorePKCS12FileKey]; len(file) == 0 {
-			el = append(el, field.Required(path.Child(csiapi.KeyStorePKCS12FileKey), "required attribute when PKCS12 KeyStore is enabled"))
-		}
-		if password := attr[csiapi.KeyStorePKCS12PasswordKey]; len(password) == 0 {
-			el = append(el, field.Required(path.Child(csiapi.KeyStorePKCS12PasswordKey), "required attribute when PKCS12 KeyStore is enabled"))
-		}
-
 		switch enable {
-		case "false", "true":
+		case "true":
+			if file := attr[csiapi.KeyStorePKCS12FileKey]; len(file) == 0 {
+				el = append(el, field.Required(path.Child(csiapi.KeyStorePKCS12FileKey), "required attribute when PKCS12 KeyStore is enabled"))
+			}
+			if password := attr[csiapi.KeyStorePKCS12PasswordKey]; len(password) == 0 {
+				el = append(el, field.Required(path.Child(csiapi.KeyStorePKCS12PasswordKey), "required attribute when PKCS12 KeyStore is enabled"))
+			}
+		case "false":
 		default:
 			el = append(el, field.NotSupported(path.Child(csiapi.KeyStorePKCS12EnableKey), enable, []string{"true", "false"}))
 		}
-
 	} else {
 		// No PKCS12 attributes should be defined when PKCS12 is not defined.
 

--- a/pkg/apis/validation/validation_test.go
+++ b/pkg/apis/validation/validation_test.go
@@ -506,6 +506,12 @@ func Test_PKCS12Values(t *testing.T) {
 			},
 			expErr: nil,
 		},
+		"if key and password are not defined, and enabled is defined as false, expect no error": {
+			attr: map[string]string{
+				"csi.cert-manager.io/pkcs12-enable": "false",
+			},
+			expErr: nil,
+		},
 		"if key and password is defined, but enabled is defined as foo, expect error": {
 			attr: map[string]string{
 				"csi.cert-manager.io/pkcs12-enable":   "foo",

--- a/pkg/filestore/writer_test.go
+++ b/pkg/filestore/writer_test.go
@@ -379,6 +379,27 @@ func Test_WriteKeypair(t *testing.T) {
 			},
 			expErr: false,
 		},
+		"keystore PKCS12 explicitly disabled should not require password": {
+			testBundle: pkcs8Bundle,
+			meta: metadata.Metadata{
+				VolumeID:   "vol-id",
+				TargetPath: "/target-path",
+				VolumeContext: map[string]string{
+					"csi.cert-manager.io/issuer-name":   "ca-issuer",
+					"csi.cert-manager.io/key-encoding":  "PKCS8",
+					"csi.cert-manager.io/pkcs12-enable": "false",
+				},
+			},
+			expFiles: map[string][]byte{
+				"ca.crt":  pkcs8Bundle.caPEM,
+				"tls.crt": pkcs8Bundle.certPEM,
+				"tls.key": pkcs8Bundle.pkPEM,
+				"metadata.json": []byte(
+					`{"volumeID":"vol-id","targetPath":"/target-path","nextIssuanceTime":"1970-01-03T00:00:00Z","volumeContext":{"csi.cert-manager.io/issuer-name":"ca-issuer","csi.cert-manager.io/key-encoding":"PKCS8","csi.cert-manager.io/pkcs12-enable":"false"}}`,
+				),
+			},
+			expErr: false,
+		},
 		"keystore PKCS12 with no password and breakout file should error": {
 			testBundle: pkcs8Bundle,
 			meta: metadata.Metadata{


### PR DESCRIPTION
### What

Tiny PKCS12 papercut fix.

When `csi.cert-manager.io/pkcs12-enable: "false"` is set, the driver should treat PKCS12 as disabled. Before this, defaulting still added `pkcs12-filename`, and validation then asked for `pkcs12-password`. thats a bit awkward ngl.

### Repro

Use volume attributes like:

```yaml
csi.cert-manager.io/issuer-name: ca-issuer
csi.cert-manager.io/key-encoding: PKCS8
csi.cert-manager.io/pkcs12-enable: "false"
```

Before this change `WriteKeypair` fails with:

```text
volumeAttributes.csi.cert-manager.io/pkcs12-password: Required value: required attribute when PKCS12 KeyStore is enabled
```

The new test covers that case. It also keeps the existing enabled path intact.

### Test

```bash
go test -count=1 ./cmd/... ./pkg/...
```
