### PR TITLE
feat: readinessgate reads pods from a node-scoped informer cache

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -32,7 +32,11 @@ import (
 	"github.com/cert-manager/csi-lib/storage"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -108,7 +112,27 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("failed to build kubernetes client: %w", err)
 				}
-				mgrOpts.ReadyToRequest = readinessgate.NewReadyToRequestFunc(k8sClient, gates) //nolint:contextcheck // manager.ReadyToRequestFunc does not accept a context; context.Background() inside is intentional.
+
+				// Scope the informer to pods on this node so cache memory is
+				// bounded to the local pod count. The driver runs as a
+				// DaemonSet, so a node-scoped informer is the right granularity.
+				nodeSelector := fields.OneTermEqualSelector("spec.nodeName", opts.NodeID).String()
+				podInformerFactory := informers.NewSharedInformerFactoryWithOptions(
+					k8sClient,
+					0, // no periodic resync; informer events are sufficient
+					informers.WithTweakListOptions(func(o *metav1.ListOptions) {
+						o.FieldSelector = nodeSelector
+					}),
+				)
+				podLister := podInformerFactory.Core().V1().Pods().Lister()
+
+				podInformerFactory.Start(ctx.Done())
+				if !cache.WaitForCacheSync(ctx.Done(), podInformerFactory.Core().V1().Pods().Informer().HasSynced) {
+					return fmt.Errorf("failed to sync pod informer cache")
+				}
+				log.Info("pod informer cache synced", "node", opts.NodeID)
+
+				mgrOpts.ReadyToRequest = readinessgate.NewReadyToRequestFunc(podLister, gates)
 			}
 
 			d, err := driver.New(ctx, opts.Endpoint, opts.Logr.WithName("driver"), driver.Options{

--- a/deploy/charts/csi-driver/templates/clusterrole.yaml
+++ b/deploy/charts/csi-driver/templates/clusterrole.yaml
@@ -8,12 +8,14 @@ rules:
 - apiGroups: ["cert-manager.io"]
   resources: ["certificaterequests"]
   verbs: ["watch", "create", "delete", "list"]
-# Required by --pod-readiness-gate to fetch the pod owning each volume and
+# Required by --pod-readiness-gate to read the pod owning each volume and
 # evaluate gate conditions (e.g. PodIPs, status conditions, annotations)
-# before issuing a CertificateRequest.
+# before issuing a CertificateRequest. The driver maintains a shared pod
+# informer scoped to the local node, which requires list and watch in
+# addition to get for cache reads.
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get"]
+  verbs: ["get", "list", "watch"]
 
 {{- /* If openshift.securityContextConstraint.enabled is set to "detect" then we 
        need to check if its an OpenShift cluster. If it is an OpenShift cluster

--- a/pkg/readinessgate/readinessgate.go
+++ b/pkg/readinessgate/readinessgate.go
@@ -26,17 +26,15 @@ limitations under the License.
 package readinessgate
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"strings"
-	"time"
 
 	"github.com/cert-manager/csi-lib/manager"
 	"github.com/cert-manager/csi-lib/metadata"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 
 	csiapi "github.com/cert-manager/csi-driver/pkg/apis/v1alpha1"
 )
@@ -66,12 +64,16 @@ func Parse(specs []string) ([]Gate, error) {
 	return gates, nil
 }
 
-// NewReadyToRequestFunc builds a manager.ReadyToRequestFunc that fetches the
-// pod owning the volume and evaluates all gates against it. All gates must
-// pass (AND semantics). Intended to be paired with --continue-on-not-ready=true
-// so that NodePublishVolume succeeds immediately and cert issuance is retried
-// asynchronously until all gates pass.
-func NewReadyToRequestFunc(client kubernetes.Interface, gates []Gate) manager.ReadyToRequestFunc {
+// NewReadyToRequestFunc builds a manager.ReadyToRequestFunc that reads the pod
+// owning the volume from the provided node-scoped pod lister and evaluates all
+// gates against it. All gates must pass (AND semantics). Intended to be paired
+// with --continue-on-not-ready=true so that NodePublishVolume succeeds
+// immediately and cert issuance is retried asynchronously until all gates pass.
+//
+// The lister is expected to be backed by a shared informer scoped to the local
+// node via a spec.nodeName field selector. Reading from the informer cache
+// avoids a per-evaluation apiserver call.
+func NewReadyToRequestFunc(podLister corev1listers.PodLister, gates []Gate) manager.ReadyToRequestFunc {
 	return func(meta metadata.Metadata) (bool, string) {
 		podName := meta.VolumeContext[csiapi.K8sVolumeContextKeyPodName]
 		podNamespace := meta.VolumeContext[csiapi.K8sVolumeContextKeyPodNamespace]
@@ -79,16 +81,15 @@ func NewReadyToRequestFunc(client kubernetes.Interface, gates []Gate) manager.Re
 			return false, "pod name or namespace not present in volume context"
 		}
 
-		// TODO: replace this live Get with a pod informer scoped to the local node
-		// (spec.nodeName field selector). The renewal loop fires every second per
-		// managed volume, so this generates one API call per second per pending volume.
-		// On a node with many pods awaiting certificates this can exhaust the client's
-		// default rate limit (5 QPS) and slow down gate evaluation.
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		pod, err := client.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
+		pod, err := podLister.Pods(podNamespace).Get(podName)
 		if err != nil {
-			return false, fmt.Sprintf("failed to get pod %s/%s: %v", podNamespace, podName, err)
+			if apierrors.IsNotFound(err) {
+				// Pod is not yet in the informer cache. This is normal in the
+				// brief window between NodePublishVolume and the informer
+				// observing the new pod. csi-lib's renewal loop will retry.
+				return false, fmt.Sprintf("pod %s/%s not yet observed by informer", podNamespace, podName)
+			}
+			return false, fmt.Sprintf("failed to read pod %s/%s from informer: %v", podNamespace, podName, err)
 		}
 
 		var reasons []string

--- a/pkg/readinessgate/readinessgate_test.go
+++ b/pkg/readinessgate/readinessgate_test.go
@@ -24,10 +24,25 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	fakeclient "k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	csiapi "github.com/cert-manager/csi-driver/pkg/apis/v1alpha1"
 )
+
+// newPodLister returns a PodLister backed by an in-memory indexer, optionally
+// pre-populated with the given pod. Used in place of the live informer to
+// exercise the readiness function's behaviour against the lister API.
+func newPodLister(t *testing.T, pod *corev1.Pod) corev1listers.PodLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	if pod != nil {
+		require.NoError(t, indexer.Add(pod))
+	}
+	return corev1listers.NewPodLister(indexer)
+}
 
 func Test_Parse(t *testing.T) {
 	tests := map[string]struct {
@@ -435,11 +450,12 @@ func Test_NewReadyToRequestFunc(t *testing.T) {
 			specs:     []string{"pod-ip:ipv6"},
 			wantReady: false,
 		},
-		"pod not found returns false": {
-			meta:      validMeta,
-			pod:       nil, // not registered in fake client
-			specs:     []string{"pod-ip:ipv6"},
-			wantReady: false,
+		"pod not yet in informer cache returns false with informer-miss reason": {
+			meta:       validMeta,
+			pod:        nil, // not added to indexer — simulates pre-sync state
+			specs:      []string{"pod-ip:ipv6"},
+			wantReady:  false,
+			wantReason: `pod my-namespace/my-pod not yet observed by informer`,
 		},
 		"single gate passes": {
 			meta:      validMeta,
@@ -504,17 +520,12 @@ func Test_NewReadyToRequestFunc(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var client *fakeclient.Clientset
-			if tc.pod != nil {
-				client = fakeclient.NewSimpleClientset(tc.pod)
-			} else {
-				client = fakeclient.NewSimpleClientset()
-			}
+			podLister := newPodLister(t, tc.pod)
 
 			gates, err := Parse(tc.specs)
 			require.NoError(t, err)
 
-			fn := NewReadyToRequestFunc(client, gates)
+			fn := NewReadyToRequestFunc(podLister, gates)
 			ready, reason := fn(tc.meta)
 			assert.Equal(t, tc.wantReady, ready)
 			if tc.wantReason != "" {


### PR DESCRIPTION
Fixes #646

## Problem

  PR #638 (the `--pod-readiness-gate` feature) currently evaluates each gate by issuing a live `client.CoreV1().Pods(ns).Get(...)` against the apiserver. csi-lib's renewal loop calls the readiness func roughly once per second per managed volume. On nodes with many pods awaiting their gates, this means:

  - One apiserver call per second per pending volume on the node.
  - The driver's client-go default rate limit (5 QPS, burst 10) is exhausted once more than ~5 pods are gate-pending simultaneously.
  - Throttling on the limiter further slows down gate evaluation that delays certificate issuance for everything on the node.
  - Avoidable load on the kube-apiserver, scaled by `pods × nodes`.

  The TODO already in `pkg/readinessgate/readinessgate.go` flagged this in the original PR. 

  ## What this PR changes

  Replaces the live GET call to apiserver with a call to **shared pod informer scoped to the local node** (via a `spec.nodeName` field selector). Gate evaluation becomes a sub-millisecond cache lookup & avoids overloading apiserver. The informer is constructed only when `--pod-readiness-gate` is provided, so deployments without the flag are unaffected.

## RBAC changes

  Informers require `list` (for initial sync) and `watch` (for ongoing updates) on the resource type, not just `get`. The current rule has only `get` (added in PR #638). Without these new verbs, the informer's `Start()` would log permission errors and
  `WaitForCacheSync` would block until context cancellation — driver startup would hang.

## Backwards compatibility

  - Deployments without `--pod-readiness-gate`: unchanged
  - Deployments with `--pod-readiness-gate`: function signature of `NewReadyToRequestFunc` changes from `(kubernetes.Interface, []Gate)` to `(corev1listers.PodLister, []Gate)`. This package is documented as **internal-to-csi-driver** and not part of any external contract