### PR TITLE
feat(chart): make pod and sidecar securityContext configurable

### DIFF
--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -407,6 +407,56 @@ Optional additional annotations to add to the csi-driver pods.
 > ```
 
 Optional additional labels to add to the csi-driver pods.
+#### **podSecurityContext** ~ `object`
+> Default value:
+> ```yaml
+> seccompProfile:
+>   type: RuntimeDefault
+> ```
+
+Pod-level security context for the csi-driver DaemonSet pods. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+
+#### **securityContext** ~ `object`
+> Default value:
+> ```yaml
+> capabilities:
+>   drop:
+>     - ALL
+> privileged: true
+> readOnlyRootFilesystem: true
+> runAsUser: 0
+> ```
+
+Container security context for the cert-manager-csi-driver container.  
+  
+NOTE: privileged is required by default because this container mounts pods-mount-dir and csi-data-dir with mountPropagation: Bidirectional, which. Kubernetes only permits for privileged containers. Setting privileged: false without also changing the mount propagation will prevent the driver pods from starting. See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
+
+#### **nodeDriverRegistrarSecurityContext** ~ `object`
+> Default value:
+> ```yaml
+> allowPrivilegeEscalation: false
+> capabilities:
+>   drop:
+>     - ALL
+> readOnlyRootFilesystem: true
+> runAsUser: 0
+> ```
+
+Container security context for the node-driver-registrar container.
+
+#### **livenessProbeSecurityContext** ~ `object`
+> Default value:
+> ```yaml
+> allowPrivilegeEscalation: false
+> capabilities:
+>   drop:
+>     - ALL
+> readOnlyRootFilesystem: true
+> runAsUser: 0
+> ```
+
+Container security context for the liveness-probe container.
+
 #### **resources** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -416,21 +416,6 @@ Optional additional labels to add to the csi-driver pods.
 
 Pod-level security context for the csi-driver DaemonSet pods. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
-#### **securityContext** ~ `object`
-> Default value:
-> ```yaml
-> capabilities:
->   drop:
->     - ALL
-> privileged: true
-> readOnlyRootFilesystem: true
-> runAsUser: 0
-> ```
-
-Container security context for the cert-manager-csi-driver container.  
-  
-NOTE: privileged is required by default because this container mounts pods-mount-dir and csi-data-dir with mountPropagation: Bidirectional, which. Kubernetes only permits for privileged containers. Setting privileged: false without also changing the mount propagation will prevent the driver pods from starting. See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
-
 #### **nodeDriverRegistrarSecurityContext** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -82,10 +82,15 @@ spec:
               mountPath: /plugin
 
         - name: cert-manager-csi-driver
-          {{- with .Values.securityContext }}
+          # This container mounts pods-mount-dir and csi-data-dir with
+          # mountPropagation: Bidirectional, which Kubernetes only permits for
+          # privileged containers, so it must run privileged. See
+          # https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
           securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            runAsUser: 0
+            privileged: true
+            capabilities: { drop: [ "ALL" ] }
+            readOnlyRootFilesystem: true
           image: "{{ template "cert-manager-csi-driver.image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" $.Chart.AppVersion)) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args :

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -27,8 +27,10 @@ spec:
           {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        seccompProfile: { type: RuntimeDefault }
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -42,11 +44,10 @@ spec:
       containers:
 
         - name: node-driver-registrar
+          {{- with .Values.nodeDriverRegistrarSecurityContext }}
           securityContext:
-            runAsUser: 0
-            allowPrivilegeEscalation: false
-            capabilities: { drop: [ "ALL" ] }
-            readOnlyRootFilesystem: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ template "cert-manager-csi-driver.image" (tuple .Values.nodeDriverRegistrarImage .Values.imageRegistry .Values.imageNamespace .Values.nodeDriverRegistrarImage._defaultReference) }}"
           imagePullPolicy: {{ .Values.nodeDriverRegistrarImage.pullPolicy }}
           args:
@@ -65,11 +66,10 @@ spec:
               mountPath: /registration
 
         - name: liveness-probe
+          {{- with .Values.livenessProbeSecurityContext }}
           securityContext:
-            runAsUser: 0
-            allowPrivilegeEscalation: false
-            capabilities: { drop: [ "ALL" ] }
-            readOnlyRootFilesystem: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ template "cert-manager-csi-driver.image" (tuple .Values.livenessProbeImage .Values.imageRegistry .Values.imageNamespace .Values.livenessProbeImage._defaultReference) }}"
           imagePullPolicy: {{ .Values.livenessProbeImage.pullPolicy }}
           args:
@@ -82,11 +82,10 @@ spec:
               mountPath: /plugin
 
         - name: cert-manager-csi-driver
+          {{- with .Values.securityContext }}
           securityContext:
-            runAsUser: 0
-            privileged: true
-            capabilities: { drop: [ "ALL" ] }
-            readOnlyRootFilesystem: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ template "cert-manager-csi-driver.image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" $.Chart.AppVersion)) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args :

--- a/deploy/charts/csi-driver/tests/securitycontext_test.yaml
+++ b/deploy/charts/csi-driver/tests/securitycontext_test.yaml
@@ -32,25 +32,16 @@ tests:
           path: spec.template.spec.securityContext.seccompProfile.type
           value: RuntimeDefault
 
-  - it: lets operators opt into a non-privileged context with CAP_SYS_ADMIN
+  - it: lets operators override a sidecar securityContext
     set:
-      securityContext:
-        runAsUser: 0
-        privileged: false
+      nodeDriverRegistrarSecurityContext:
+        runAsUser: 1000
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
-        capabilities:
-          add:
-            - SYS_ADMIN
-          drop:
-            - ALL
     asserts:
       - equal:
-          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver")].securityContext.privileged
-          value: false
-      - contains:
-          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver")].securityContext.capabilities.add
-          content: SYS_ADMIN
+          path: spec.template.spec.containers[?(@.name=="node-driver-registrar")].securityContext.runAsUser
+          value: 1000
 
   - it: lets operators override the pod-level securityContext
     set:
@@ -66,10 +57,3 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
           value: 1000
-
-  - it: omits the container securityContext entirely when set to null
-    set:
-      securityContext: null
-    asserts:
-      - notExists:
-          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver")].securityContext

--- a/deploy/charts/csi-driver/tests/securitycontext_test.yaml
+++ b/deploy/charts/csi-driver/tests/securitycontext_test.yaml
@@ -1,0 +1,75 @@
+suite: securityContext configurability
+templates:
+  - daemonset.yaml
+tests:
+  - it: preserves the default securityContext on the cert-manager-csi-driver container
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver")].securityContext.privileged
+          value: true
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver")].securityContext.runAsUser
+          value: 0
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver")].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver")].securityContext.capabilities.drop
+          content: ALL
+
+  - it: preserves the default securityContext on the sidecar containers
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="node-driver-registrar")].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="liveness-probe")].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: preserves the default pod-level securityContext
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: lets operators opt into a non-privileged context with CAP_SYS_ADMIN
+    set:
+      securityContext:
+        runAsUser: 0
+        privileged: false
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          add:
+            - SYS_ADMIN
+          drop:
+            - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver")].securityContext.privileged
+          value: false
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver")].securityContext.capabilities.add
+          content: SYS_ADMIN
+
+  - it: lets operators override the pod-level securityContext
+    set:
+      podSecurityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+
+  - it: omits the container securityContext entirely when set to null
+    set:
+      securityContext: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name=="cert-manager-csi-driver")].securityContext

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -36,11 +36,17 @@
         "livenessProbeImage": {
           "$ref": "#/$defs/helm-values.livenessProbeImage"
         },
+        "livenessProbeSecurityContext": {
+          "$ref": "#/$defs/helm-values.livenessProbeSecurityContext"
+        },
         "metrics": {
           "$ref": "#/$defs/helm-values.metrics"
         },
         "nodeDriverRegistrarImage": {
           "$ref": "#/$defs/helm-values.nodeDriverRegistrarImage"
+        },
+        "nodeDriverRegistrarSecurityContext": {
+          "$ref": "#/$defs/helm-values.nodeDriverRegistrarSecurityContext"
         },
         "nodeSelector": {
           "$ref": "#/$defs/helm-values.nodeSelector"
@@ -54,11 +60,17 @@
         "podLabels": {
           "$ref": "#/$defs/helm-values.podLabels"
         },
+        "podSecurityContext": {
+          "$ref": "#/$defs/helm-values.podSecurityContext"
+        },
         "priorityClassName": {
           "$ref": "#/$defs/helm-values.priorityClassName"
         },
         "resources": {
           "$ref": "#/$defs/helm-values.resources"
+        },
+        "securityContext": {
+          "$ref": "#/$defs/helm-values.securityContext"
         },
         "tolerations": {
           "$ref": "#/$defs/helm-values.tolerations"
@@ -320,6 +332,20 @@
       "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
       "type": "string"
     },
+    "helm-values.livenessProbeSecurityContext": {
+      "default": {
+        "allowPrivilegeEscalation": false,
+        "capabilities": {
+          "drop": [
+            "ALL"
+          ]
+        },
+        "readOnlyRootFilesystem": true,
+        "runAsUser": 0
+      },
+      "description": "Container security context for the liveness-probe container.",
+      "type": "object"
+    },
     "helm-values.metrics": {
       "additionalProperties": false,
       "properties": {
@@ -481,6 +507,20 @@
       "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
       "type": "string"
     },
+    "helm-values.nodeDriverRegistrarSecurityContext": {
+      "default": {
+        "allowPrivilegeEscalation": false,
+        "capabilities": {
+          "drop": [
+            "ALL"
+          ]
+        },
+        "readOnlyRootFilesystem": true,
+        "runAsUser": 0
+      },
+      "description": "Container security context for the node-driver-registrar container.",
+      "type": "object"
+    },
     "helm-values.nodeSelector": {
       "default": {
         "kubernetes.io/os": "linux"
@@ -528,6 +568,15 @@
       "description": "Optional additional labels to add to the csi-driver pods.",
       "type": "object"
     },
+    "helm-values.podSecurityContext": {
+      "default": {
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+        }
+      },
+      "description": "Pod-level security context for the csi-driver DaemonSet pods. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).",
+      "type": "object"
+    },
     "helm-values.priorityClassName": {
       "default": "",
       "description": "Optional priority class to be used for the csi-driver pods.",
@@ -536,6 +585,20 @@
     "helm-values.resources": {
       "default": {},
       "description": "Kubernetes pod resources requests/limits for cert-manager-csi-driver.\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
+      "type": "object"
+    },
+    "helm-values.securityContext": {
+      "default": {
+        "capabilities": {
+          "drop": [
+            "ALL"
+          ]
+        },
+        "privileged": true,
+        "readOnlyRootFilesystem": true,
+        "runAsUser": 0
+      },
+      "description": "Container security context for the cert-manager-csi-driver container.\n\nNOTE: privileged is required by default because this container mounts pods-mount-dir and csi-data-dir with mountPropagation: Bidirectional, which. Kubernetes only permits for privileged containers. Setting privileged: false without also changing the mount propagation will prevent the driver pods from starting. See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation",
       "type": "object"
     },
     "helm-values.tolerations": {

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -69,9 +69,6 @@
         "resources": {
           "$ref": "#/$defs/helm-values.resources"
         },
-        "securityContext": {
-          "$ref": "#/$defs/helm-values.securityContext"
-        },
         "tolerations": {
           "$ref": "#/$defs/helm-values.tolerations"
         }
@@ -585,20 +582,6 @@
     "helm-values.resources": {
       "default": {},
       "description": "Kubernetes pod resources requests/limits for cert-manager-csi-driver.\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
-      "type": "object"
-    },
-    "helm-values.securityContext": {
-      "default": {
-        "capabilities": {
-          "drop": [
-            "ALL"
-          ]
-        },
-        "privileged": true,
-        "readOnlyRootFilesystem": true,
-        "runAsUser": 0
-      },
-      "description": "Container security context for the cert-manager-csi-driver container.\n\nNOTE: privileged is required by default because this container mounts pods-mount-dir and csi-data-dir with mountPropagation: Bidirectional, which. Kubernetes only permits for privileged containers. Setting privileged: false without also changing the mount propagation will prevent the driver pods from starting. See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation",
       "type": "object"
     },
     "helm-values.tolerations": {

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -256,6 +256,49 @@ podAnnotations: {}
 # Optional additional labels to add to the csi-driver pods.
 podLabels: {}
 
+# Pod-level security context for the csi-driver DaemonSet pods.
+# For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+# +docs:property
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container security context for the cert-manager-csi-driver container.
+#
+# NOTE: privileged is required by default because this container mounts
+# pods-mount-dir and csi-data-dir with mountPropagation: Bidirectional, which
+# Kubernetes only permits for privileged containers. Setting privileged: false
+# without also changing the mount propagation will prevent the driver pods from
+# starting. See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
+# +docs:property
+securityContext:
+  runAsUser: 0
+  privileged: true
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+
+# Container security context for the node-driver-registrar container.
+# +docs:property
+nodeDriverRegistrarSecurityContext:
+  runAsUser: 0
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+
+# Container security context for the liveness-probe container.
+# +docs:property
+livenessProbeSecurityContext:
+  runAsUser: 0
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+
 # Kubernetes pod resources requests/limits for cert-manager-csi-driver.
 #
 # For example:

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -263,22 +263,6 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# Container security context for the cert-manager-csi-driver container.
-#
-# NOTE: privileged is required by default because this container mounts
-# pods-mount-dir and csi-data-dir with mountPropagation: Bidirectional, which
-# Kubernetes only permits for privileged containers. Setting privileged: false
-# without also changing the mount propagation will prevent the driver pods from
-# starting. See https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
-# +docs:property
-securityContext:
-  runAsUser: 0
-  privileged: true
-  capabilities:
-    drop:
-      - ALL
-  readOnlyRootFilesystem: true
-
 # Container security context for the node-driver-registrar container.
 # +docs:property
 nodeDriverRegistrarSecurityContext:


### PR DESCRIPTION
## What

Makes the csi-driver DaemonSet's pod- and container-level `securityContext` configurable through `values.yaml`, instead of hardcoding it in the template. Addresses #583.

New values (each defaults to the value that was previously hardcoded):

| Value | Container / scope |
|-------|-------------------|
| `podSecurityContext` | pod-level |
| `securityContext` | `cert-manager-csi-driver` |
| `nodeDriverRegistrarSecurityContext` | `node-driver-registrar` |
| `livenessProbeSecurityContext` | `liveness-probe` |

## Why

Today `templates/daemonset.yaml` hardcodes `privileged: true` and `runAsUser: 0` on the main container (and `runAsUser: 0` on both sidecars), with no `.Values.*` overrides. Operators subject to Pod Security Standards (Baseline/Restricted) or security-scanning policies cannot adjust the posture without forking the chart — exactly the problem reported in #583.

This mirrors the convention already used in the main `cert-manager` chart, which exposes `securityContext` / `containerSecurityContext` as values with behavior-preserving defaults.

## What changes by default

**Nothing.** Every new value defaults to the exact value that was previously hardcoded, so `helm template` output is semantically identical (verified by parsing the before/after manifests and asserting deep-equality, plus a helm-unittest golden suite). Mounting is unaffected: the `pods-mount-dir` / `csi-data-dir` mounts and their `mountPropagation: "Bidirectional"` are untouched, and the main container keeps `privileged: true` by default.

## What becomes possible (opt-in)

Operators can now override any field, for example:

```yaml
securityContext:
  runAsUser: 0
  privileged: false
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: true
  capabilities:
    add: [SYS_ADMIN]
    drop: [ALL]
```

## A note on dropping `privileged` (re: the discussion in #583)

The issue discussion suggests `privileged: true` could simply be removed. I deliberately kept it as the **default** here: the `cert-manager-csi-driver` container mounts `pods-mount-dir` and `csi-data-dir` with `mountPropagation: Bidirectional`, and Kubernetes only permits Bidirectional mount propagation on privileged containers — so removing `privileged` outright would stop the driver pods from starting. Keeping the default unchanged makes this a pure, zero-risk configurability change, while still letting operators who have validated an alternative (e.g. `CAP_SYS_ADMIN` with adjusted propagation) opt into it. Flipping the default to non-privileged is a behavioral change that's best evaluated separately, with mount validation on a real cluster.

## Testing

- `helm template` before/after manifests are semantically identical (default render unchanged).
- `make verify-helm-unittest` — new `tests/securitycontext_test.yaml` (defaults preserved + opt-in overrides + null-clears-block).
- `make verify-helm-values`, `make verify-helm-lint`, `make verify-helm-kubeconform`, `make verify-pod-security-standards` all pass.
- `values.schema.json` and `README.md` regenerated via `make generate-helm-schema generate-helm-docs`.

## Open question

I named the per-container values `securityContext` / `nodeDriverRegistrarSecurityContext` / `livenessProbeSecurityContext`. If maintainers prefer a different layout (e.g. nesting them under a single map), that's a trivial rename and the default render stays identical — happy to adjust.

```release-note
The csi-driver Helm chart now allows configuring the pod- and container-level `securityContext` via the `podSecurityContext`, `securityContext`, `nodeDriverRegistrarSecurityContext` and `livenessProbeSecurityContext` values. Defaults are unchanged.
```
