### PR TITLE
wire csi-lib GateBackoffConfig as --gate-backoff-* flags and Helm values

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -95,6 +95,11 @@ func NewCommand(ctx context.Context) *cobra.Command {
 			if len(gates) > 0 && !opts.ContinueOnNotReady {
 				return fmt.Errorf("--pod-readiness-gate requires --continue-on-not-ready=true")
 			}
+			if len(gates) > 0 {
+				if err := validateGateBackoff(opts); err != nil {
+					return err
+				}
+			}
 
 			mngrlog := opts.Logr.WithName("manager")
 			mgrOpts := manager.Options{
@@ -242,4 +247,24 @@ func signRequest(_ metadata.Metadata, key crypto.PrivateKey, request *x509.Certi
 		Type:  "CERTIFICATE REQUEST",
 		Bytes: csrDer,
 	}), nil
+}
+
+// validateGateBackoff sanity-checks the --gate-backoff-* flag values so a
+// misconfigured operator gets a clear startup error rather than a runtime
+// retry storm (e.g. Duration=0 → infinite no-wait spin, Jitter>1 → undefined
+// behaviour in wait.Backoff).
+func validateGateBackoff(opts *options.Options) error {
+	if opts.GateBackoffDuration <= 0 {
+		return fmt.Errorf("--gate-backoff-duration must be > 0, got %s", opts.GateBackoffDuration)
+	}
+	if opts.GateBackoffFactor < 1 {
+		return fmt.Errorf("--gate-backoff-factor must be >= 1, got %v", opts.GateBackoffFactor)
+	}
+	if opts.GateBackoffJitter < 0 || opts.GateBackoffJitter > 1 {
+		return fmt.Errorf("--gate-backoff-jitter must be in [0, 1], got %v", opts.GateBackoffJitter)
+	}
+	if opts.GateBackoffCap < opts.GateBackoffDuration {
+		return fmt.Errorf("--gate-backoff-cap (%s) must be >= --gate-backoff-duration (%s)", opts.GateBackoffCap, opts.GateBackoffDuration)
+	}
+	return nil
 }

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"math"
 	"net/http"
 
 	"github.com/cert-manager/csi-lib/driver"
@@ -34,6 +35,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -133,6 +135,17 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				log.Info("pod informer cache synced", "node", opts.NodeID)
 
 				mgrOpts.ReadyToRequest = readinessgate.NewReadyToRequestFunc(podLister, gates)
+
+				// Gate-pending backoff applies only when ReadyToRequestFunc can
+				// return false, which is only true when readiness gates are set.
+				// Flag defaults mirror csi-lib's own defaults for GateBackoffConfig.
+				mgrOpts.GateBackoffConfig = &wait.Backoff{
+					Duration: opts.GateBackoffDuration,
+					Factor:   opts.GateBackoffFactor,
+					Jitter:   opts.GateBackoffJitter,
+					Cap:      opts.GateBackoffCap,
+					Steps:    math.MaxInt32,
+				}
 			}
 
 			d, err := driver.New(ctx, opts.Endpoint, opts.Logr.WithName("driver"), driver.Options{

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cert-manager/csi-lib/metadata"
 	"github.com/cert-manager/csi-lib/storage"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -140,26 +141,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				log.Info("pod informer cache synced", "node", opts.NodeID)
 
 				mgrOpts.ReadyToRequest = readinessgate.NewReadyToRequestFunc(podLister, gates)
-
-				// Only build GateBackoffConfig if the operator explicitly set
-				// one of the --gate-backoff-* flags. Our flag defaults happen
-				// to mirror csi-lib's own GateBackoffConfig defaults today, but
-				// hardcoding them here would silently pin csi-driver to stale
-				// values if csi-lib ever changes its defaults. Leaving
-				// GateBackoffConfig nil lets csi-lib apply its own (possibly
-				// updated) defaults.
-				if fs := cmd.Flags(); fs.Changed("gate-backoff-duration") ||
-					fs.Changed("gate-backoff-factor") ||
-					fs.Changed("gate-backoff-jitter") ||
-					fs.Changed("gate-backoff-cap") {
-					mgrOpts.GateBackoffConfig = &wait.Backoff{
-						Duration: opts.GateBackoffDuration,
-						Factor:   opts.GateBackoffFactor,
-						Jitter:   opts.GateBackoffJitter,
-						Cap:      opts.GateBackoffCap,
-						Steps:    math.MaxInt32,
-					}
-				}
+				mgrOpts.GateBackoffConfig = gateBackoffConfigFromFlags(cmd.Flags(), opts)
 			}
 
 			d, err := driver.New(ctx, opts.Endpoint, opts.Logr.WithName("driver"), driver.Options{
@@ -281,4 +263,39 @@ func validateGateBackoff(opts *options.Options) error {
 		return fmt.Errorf("--gate-backoff-cap (%s) must be 0 (uncapped) or >= --gate-backoff-duration (%s)", opts.GateBackoffCap, opts.GateBackoffDuration)
 	}
 	return nil
+}
+
+// gateBackoffConfigFromFlags builds the wait.Backoff passed to csi-lib's
+// manager.Options.GateBackoffConfig, or returns nil if the operator hasn't
+// touched any --gate-backoff-* flag at all, so csi-lib applies its own
+// (possibly newer) defaults instead of a stale copy of them.
+//
+// NOTE: this is all-or-nothing, not per-field. If *any* one of the four
+// flags was explicitly set (fs.Changed), the resulting struct pins *all
+// four* fields to their current CLI values -- including the three left
+// untouched, which just hold pflag's registered defaults. Those defaults
+// happen to mirror csi-lib's own GateBackoffConfig defaults today, but
+// aren't dynamically sourced from it, so a future csi-lib default bump
+// won't be picked up for the untouched fields once any one flag is set.
+// True per-field deferral would require csi-lib itself to merge partial
+// overrides against its own defaults field-by-field (it currently only
+// checks whether the whole GateBackoffConfig is nil), which is out of
+// scope for this repo. Until then, operators who override one gate-backoff
+// flag should be aware they are implicitly pinning the rest to the CLI's
+// current defaults, not deferring them to csi-lib.
+func gateBackoffConfigFromFlags(fs *pflag.FlagSet, opts *options.Options) *wait.Backoff {
+	if !fs.Changed("gate-backoff-duration") &&
+		!fs.Changed("gate-backoff-factor") &&
+		!fs.Changed("gate-backoff-jitter") &&
+		!fs.Changed("gate-backoff-cap") {
+		return nil
+	}
+
+	return &wait.Backoff{
+		Duration: opts.GateBackoffDuration,
+		Factor:   opts.GateBackoffFactor,
+		Jitter:   opts.GateBackoffJitter,
+		Cap:      opts.GateBackoffCap,
+		Steps:    math.MaxInt32,
+	}
 }

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -272,8 +272,13 @@ func validateGateBackoff(opts *options.Options) error {
 	if opts.GateBackoffJitter < 0 || opts.GateBackoffJitter > 1 {
 		return fmt.Errorf("--gate-backoff-jitter must be in [0, 1], got %v", opts.GateBackoffJitter)
 	}
-	if opts.GateBackoffCap < opts.GateBackoffDuration {
-		return fmt.Errorf("--gate-backoff-cap (%s) must be >= --gate-backoff-duration (%s)", opts.GateBackoffCap, opts.GateBackoffDuration)
+	// wait.Backoff treats Cap == 0 as "no cap" (see its delay() implementation:
+	// the cap is only applied when cap > 0), so it's a valid way to request
+	// unbounded exponential growth. Any other non-positive or sub-duration cap
+	// is nonsensical, since it would either immediately cap every step to
+	// less than the base duration or be silently negative.
+	if opts.GateBackoffCap != 0 && opts.GateBackoffCap < opts.GateBackoffDuration {
+		return fmt.Errorf("--gate-backoff-cap (%s) must be 0 (uncapped) or >= --gate-backoff-duration (%s)", opts.GateBackoffCap, opts.GateBackoffDuration)
 	}
 	return nil
 }

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -141,15 +141,24 @@ func NewCommand(ctx context.Context) *cobra.Command {
 
 				mgrOpts.ReadyToRequest = readinessgate.NewReadyToRequestFunc(podLister, gates)
 
-				// Gate-pending backoff applies only when ReadyToRequestFunc can
-				// return false, which is only true when readiness gates are set.
-				// Flag defaults mirror csi-lib's own defaults for GateBackoffConfig.
-				mgrOpts.GateBackoffConfig = &wait.Backoff{
-					Duration: opts.GateBackoffDuration,
-					Factor:   opts.GateBackoffFactor,
-					Jitter:   opts.GateBackoffJitter,
-					Cap:      opts.GateBackoffCap,
-					Steps:    math.MaxInt32,
+				// Only build GateBackoffConfig if the operator explicitly set
+				// one of the --gate-backoff-* flags. Our flag defaults happen
+				// to mirror csi-lib's own GateBackoffConfig defaults today, but
+				// hardcoding them here would silently pin csi-driver to stale
+				// values if csi-lib ever changes its defaults. Leaving
+				// GateBackoffConfig nil lets csi-lib apply its own (possibly
+				// updated) defaults.
+				if fs := cmd.Flags(); fs.Changed("gate-backoff-duration") ||
+					fs.Changed("gate-backoff-factor") ||
+					fs.Changed("gate-backoff-jitter") ||
+					fs.Changed("gate-backoff-cap") {
+					mgrOpts.GateBackoffConfig = &wait.Backoff{
+						Duration: opts.GateBackoffDuration,
+						Factor:   opts.GateBackoffFactor,
+						Jitter:   opts.GateBackoffJitter,
+						Cap:      opts.GateBackoffCap,
+						Steps:    math.MaxInt32,
+					}
 				}
 			}
 

--- a/cmd/app/app_test.go
+++ b/cmd/app/app_test.go
@@ -84,7 +84,24 @@ func TestValidateGateBackoff(t *testing.T) {
 				GateBackoffFactor:   1,
 				GateBackoffCap:      10 * time.Second,
 			},
-			wantErr: "--gate-backoff-cap (10s) must be >= --gate-backoff-duration (30s)",
+			wantErr: "--gate-backoff-cap (10s) must be 0 (uncapped) or >= --gate-backoff-duration (30s)",
+		},
+		"cap zero is uncapped and valid": {
+			opts: options.Options{
+				GateBackoffDuration: 30 * time.Second,
+				GateBackoffFactor:   2,
+				GateBackoffJitter:   0.5,
+				GateBackoffCap:      0,
+			},
+		},
+		"cap negative is invalid": {
+			opts: options.Options{
+				GateBackoffDuration: time.Second,
+				GateBackoffFactor:   2,
+				GateBackoffJitter:   0.5,
+				GateBackoffCap:      -time.Second,
+			},
+			wantErr: "--gate-backoff-cap (-1s) must be 0 (uncapped) or >= --gate-backoff-duration (1s)",
 		},
 	}
 

--- a/cmd/app/app_test.go
+++ b/cmd/app/app_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cert-manager/csi-driver/cmd/app/options"
+)
+
+func TestValidateGateBackoff(t *testing.T) {
+	tests := map[string]struct {
+		opts    options.Options
+		wantErr string
+	}{
+		"valid defaults": {
+			opts: options.Options{
+				GateBackoffDuration: time.Second,
+				GateBackoffFactor:   2,
+				GateBackoffJitter:   0.5,
+				GateBackoffCap:      10 * time.Second,
+			},
+		},
+		"zero duration": {
+			opts: options.Options{
+				GateBackoffCap: time.Second,
+			},
+			wantErr: "--gate-backoff-duration must be > 0",
+		},
+		"negative duration": {
+			opts: options.Options{
+				GateBackoffDuration: -time.Second,
+				GateBackoffCap:      time.Second,
+			},
+			wantErr: "--gate-backoff-duration must be > 0",
+		},
+		"factor below 1": {
+			opts: options.Options{
+				GateBackoffDuration: time.Second,
+				GateBackoffFactor:   0.5,
+				GateBackoffCap:      time.Second,
+			},
+			wantErr: "--gate-backoff-factor must be >= 1",
+		},
+		"jitter negative": {
+			opts: options.Options{
+				GateBackoffDuration: time.Second,
+				GateBackoffFactor:   2,
+				GateBackoffJitter:   -0.1,
+				GateBackoffCap:      time.Second,
+			},
+			wantErr: "--gate-backoff-jitter must be in [0, 1]",
+		},
+		"jitter above 1": {
+			opts: options.Options{
+				GateBackoffDuration: time.Second,
+				GateBackoffFactor:   2,
+				GateBackoffJitter:   1.1,
+				GateBackoffCap:      time.Second,
+			},
+			wantErr: "--gate-backoff-jitter must be in [0, 1]",
+		},
+		"cap below duration": {
+			opts: options.Options{
+				GateBackoffDuration: 30 * time.Second,
+				GateBackoffFactor:   1,
+				GateBackoffCap:      10 * time.Second,
+			},
+			wantErr: "--gate-backoff-cap (10s) must be >= --gate-backoff-duration (30s)",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateGateBackoff(&test.opts)
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantErr)
+		})
+	}
+}

--- a/cmd/app/app_test.go
+++ b/cmd/app/app_test.go
@@ -17,14 +17,29 @@ limitations under the License.
 package app
 
 import (
+	"math"
 	"testing"
 	"time"
 
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/cert-manager/csi-driver/cmd/app/options"
 )
+
+// newGateBackoffFlagSet registers just the four --gate-backoff-* flags
+// (mirroring options.addAppFlags) so gateBackoffConfigFromFlags can be
+// exercised standalone, including its FlagSet.Changed() checks.
+func newGateBackoffFlagSet(opts *options.Options) *pflag.FlagSet {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.DurationVar(&opts.GateBackoffDuration, "gate-backoff-duration", time.Second, "")
+	fs.Float64Var(&opts.GateBackoffFactor, "gate-backoff-factor", 2.0, "")
+	fs.Float64Var(&opts.GateBackoffJitter, "gate-backoff-jitter", 0.5, "")
+	fs.DurationVar(&opts.GateBackoffCap, "gate-backoff-cap", 10*time.Second, "")
+	return fs
+}
 
 func TestValidateGateBackoff(t *testing.T) {
 	tests := map[string]struct {
@@ -114,6 +129,81 @@ func TestValidateGateBackoff(t *testing.T) {
 			}
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), test.wantErr)
+		})
+	}
+}
+
+// TestGateBackoffConfigFromFlags exercises the partial-flag scenarios flagged
+// in review: setting only *some* of the --gate-backoff-* flags must still
+// produce a fully-populated wait.Backoff (today's known, documented
+// limitation - see gateBackoffConfigFromFlags), while leaving *all* of them
+// untouched must defer to csi-lib entirely by returning nil.
+func TestGateBackoffConfigFromFlags(t *testing.T) {
+	tests := map[string]struct {
+		setFlags map[string]string // flag name -> value to explicitly set
+		want     *wait.Backoff
+	}{
+		"no flags set defers to csi-lib (nil)": {
+			setFlags: nil,
+			want:     nil,
+		},
+		"only duration set pins all four fields": {
+			setFlags: map[string]string{"gate-backoff-duration": "5s"},
+			want: &wait.Backoff{
+				Duration: 5 * time.Second,
+				Factor:   2.0, // untouched: pflag's registered default, not csi-lib's
+				Jitter:   0.5, // untouched: pflag's registered default, not csi-lib's
+				Cap:      10 * time.Second,
+				Steps:    math.MaxInt32,
+			},
+		},
+		"only cap set pins all four fields": {
+			setFlags: map[string]string{"gate-backoff-cap": "0s"},
+			want: &wait.Backoff{
+				Duration: time.Second,
+				Factor:   2.0,
+				Jitter:   0.5,
+				Cap:      0,
+				Steps:    math.MaxInt32,
+			},
+		},
+		"duration and cap set (typical Helm per-field override) pins all four fields": {
+			setFlags: map[string]string{"gate-backoff-duration": "2s", "gate-backoff-cap": "0s"},
+			want: &wait.Backoff{
+				Duration: 2 * time.Second,
+				Factor:   2.0,
+				Jitter:   0.5,
+				Cap:      0,
+				Steps:    math.MaxInt32,
+			},
+		},
+		"all four flags set": {
+			setFlags: map[string]string{
+				"gate-backoff-duration": "3s",
+				"gate-backoff-factor":   "1.5",
+				"gate-backoff-jitter":   "0.2",
+				"gate-backoff-cap":      "30s",
+			},
+			want: &wait.Backoff{
+				Duration: 3 * time.Second,
+				Factor:   1.5,
+				Jitter:   0.2,
+				Cap:      30 * time.Second,
+				Steps:    math.MaxInt32,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts := &options.Options{}
+			fs := newGateBackoffFlagSet(opts)
+			for name, value := range test.setFlags {
+				require.NoError(t, fs.Set(name, value))
+			}
+
+			got := gateBackoffConfigFromFlags(fs, opts)
+			assert.Equal(t, test.want, got)
 		})
 	}
 }

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -227,10 +227,17 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	// Gate-pending backoff: applied between readiness-gate checks while the gate
 	// is not yet met. Distinct from the renewal backoff used for issuance errors,
 	// which is configured by csi-lib's defaults. Defaults below mirror csi-lib's
-	// own defaults for GateBackoffConfig; app.go only builds a GateBackoffConfig
-	// when one of these flags was actually set (via FlagSet.Changed), so leaving
-	// them at these defaults is a true no-op rather than a value that shadows a
-	// future csi-lib default change.
+	// own defaults for GateBackoffConfig. app.go's gateBackoffConfigFromFlags
+	// only builds a GateBackoffConfig if at least one of these flags was
+	// explicitly set (via FlagSet.Changed), so leaving *all* of them untouched
+	// is a true no-op that defers entirely to csi-lib's defaults.
+	//
+	// NOTE this is all-or-nothing, not per-field: setting any *one* of these
+	// flags pins all four fields (including the ones left at these defaults)
+	// to their current CLI values for the lifetime of the process. If csi-lib
+	// later changes its own defaults, an operator who only overrode e.g.
+	// gate-backoff-duration will keep today's factor/jitter/cap values rather
+	// than picking up the new ones. See gateBackoffConfigFromFlags for details.
 	fs.DurationVar(&o.GateBackoffDuration, "gate-backoff-duration", time.Second,
 		"Base duration between gate-pending retries when --pod-readiness-gate is set.")
 	fs.Float64Var(&o.GateBackoffFactor, "gate-backoff-factor", 2.0,

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -227,7 +227,10 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	// Gate-pending backoff: applied between readiness-gate checks while the gate
 	// is not yet met. Distinct from the renewal backoff used for issuance errors,
 	// which is configured by csi-lib's defaults. Defaults below mirror csi-lib's
-	// own defaults for GateBackoffConfig so leaving them unset is a no-op.
+	// own defaults for GateBackoffConfig; app.go only builds a GateBackoffConfig
+	// when one of these flags was actually set (via FlagSet.Changed), so leaving
+	// them at these defaults is a true no-op rather than a value that shadows a
+	// future csi-lib default change.
 	fs.DurationVar(&o.GateBackoffDuration, "gate-backoff-duration", time.Second,
 		"Base duration between gate-pending retries when --pod-readiness-gate is set.")
 	fs.Float64Var(&o.GateBackoffFactor, "gate-backoff-factor", 2.0,

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -238,5 +238,5 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	fs.Float64Var(&o.GateBackoffJitter, "gate-backoff-jitter", 0.5,
 		"Random jitter (+/- fraction of duration) applied to each gate-pending wait.")
 	fs.DurationVar(&o.GateBackoffCap, "gate-backoff-cap", 10*time.Second,
-		"Maximum duration between gate-pending retries.")
+		"Maximum duration between gate-pending retries. A value of 0 disables the cap, allowing unbounded exponential growth.")
 }

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -19,6 +19,7 @@ package options
 import (
 	"flag"
 	"fmt"
+	"time"
 
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	"github.com/go-logr/logr"
@@ -98,6 +99,24 @@ type Options struct {
 	// KubernetesAPIBurst is the maximum burst queries-per-second of requests
 	// sent to the Kubernetes apiserver.
 	KubernetesAPIBurst int
+
+	// GateBackoffDuration is the base backoff applied when ReadyToRequestFunc
+	// (i.e. the readiness gates) reports the driver is not yet ready to issue.
+	// Gate-pending is a wait state, not a failure, and warrants a much faster
+	// retry cadence than the renewal backoff used for issuance errors. Defaults
+	// mirror csi-lib's defaults for GateBackoffConfig.
+	GateBackoffDuration time.Duration
+
+	// GateBackoffFactor multiplies GateBackoffDuration after each failed
+	// gate-pending attempt.
+	GateBackoffFactor float64
+
+	// GateBackoffJitter applies +/- this fraction of the duration to each
+	// gate-pending wait.
+	GateBackoffJitter float64
+
+	// GateBackoffCap is the maximum duration between gate-pending retries.
+	GateBackoffCap time.Duration
 }
 
 func New() *Options {
@@ -204,4 +223,17 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 			"  pod-condition:<Type>[=<Status>]    Status defaults to True\n"+
 			"  pod-annotation:<key>               annotation key must be present\n"+
 			"Must be combined with --continue-on-not-ready=true to avoid blocking NodePublishVolume.")
+
+	// Gate-pending backoff: applied between readiness-gate checks while the gate
+	// is not yet met. Distinct from the renewal backoff used for issuance errors,
+	// which is configured by csi-lib's defaults. Defaults below mirror csi-lib's
+	// own defaults for GateBackoffConfig so leaving them unset is a no-op.
+	fs.DurationVar(&o.GateBackoffDuration, "gate-backoff-duration", time.Second,
+		"Base duration between gate-pending retries when --pod-readiness-gate is set.")
+	fs.Float64Var(&o.GateBackoffFactor, "gate-backoff-factor", 2.0,
+		"Multiplier applied to gate-backoff-duration after each failed gate check.")
+	fs.Float64Var(&o.GateBackoffJitter, "gate-backoff-jitter", 0.5,
+		"Random jitter (+/- fraction of duration) applied to each gate-pending wait.")
+	fs.DurationVar(&o.GateBackoffCap, "gate-backoff-cap", 10*time.Second,
+		"Maximum duration between gate-pending retries.")
 }

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -370,21 +370,29 @@ Examples:
 > ```yaml
 > 1s
 > ```
+
+Base duration between gate-pending retries. The wait between the first failed gate check and the next attempt.
 #### **app.driver.gateBackoff.factor** ~ `number`
 > Default value:
 > ```yaml
 > 2
 > ```
+
+Multiplier applied to the previous wait after each failed gate check. Must be >= 1. With factor=1, the wait stays constant at `duration`.
 #### **app.driver.gateBackoff.jitter** ~ `number`
 > Default value:
 > ```yaml
 > 0.5
 > ```
+
+Random jitter applied as +/- this fraction of the current wait. Must be in [0, 1]. With jitter=0, retries are deterministic.
 #### **app.driver.gateBackoff.cap** ~ `string`
 > Default value:
 > ```yaml
-> 60s
+> 10s
 > ```
+
+Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be >= `duration`.
 #### **app.driver.csiDataDir** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -365,6 +365,26 @@ Examples:
   - "pod-ip:ipv6"  
   - "pod-condition:NetworkAttached=True"  
   - "pod-annotation:k8s.v1.cni.cncf.io/networks-status"
+#### **app.driver.gateBackoff.duration** ~ `string`
+> Default value:
+> ```yaml
+> 1s
+> ```
+#### **app.driver.gateBackoff.factor** ~ `number`
+> Default value:
+> ```yaml
+> 2
+> ```
+#### **app.driver.gateBackoff.jitter** ~ `number`
+> Default value:
+> ```yaml
+> 0.5
+> ```
+#### **app.driver.gateBackoff.cap** ~ `string`
+> Default value:
+> ```yaml
+> 10s
+> ```
 #### **app.driver.csiDataDir** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -365,34 +365,35 @@ Examples:
   - "pod-ip:ipv6"  
   - "pod-condition:NetworkAttached=True"  
   - "pod-annotation:k8s.v1.cni.cncf.io/networks-status"
-#### **app.driver.gateBackoff.duration** ~ `string`
+#### **app.driver.gateBackoff.duration** ~ `unknown`
 > Default value:
 > ```yaml
-> 1s
+> null
 > ```
 
-Base duration between gate-pending retries. The wait between the first failed gate check and the next attempt.
-#### **app.driver.gateBackoff.factor** ~ `number`
+Base duration between gate-pending retries. The wait between the first failed gate check and the next attempt. Unset defers to csi-lib's default.
+#### **app.driver.gateBackoff.factor** ~ `unknown`
 > Default value:
 > ```yaml
-> 2
+> null
 > ```
 
-Multiplier applied to the previous wait after each failed gate check. Must be >= 1. With factor=1, the wait stays constant at `duration`.
-#### **app.driver.gateBackoff.jitter** ~ `number`
+Multiplier applied to the previous wait after each failed gate check. Must be >= 1. With factor=1, the wait stays constant at `duration`.  
+Unset defers to csi-lib's default.
+#### **app.driver.gateBackoff.jitter** ~ `unknown`
 > Default value:
 > ```yaml
-> 0.5
+> null
 > ```
 
-Random jitter applied as +/- this fraction of the current wait. Must be in [0, 1]. With jitter=0, retries are deterministic.
-#### **app.driver.gateBackoff.cap** ~ `string`
+Random jitter applied as +/- this fraction of the current wait. Must be in [0, 1]. With jitter=0, retries are deterministic. Unset defers to csi-lib's default.
+#### **app.driver.gateBackoff.cap** ~ `unknown`
 > Default value:
 > ```yaml
-> 10s
+> null
 > ```
 
-Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be >= `duration`.
+Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be >= `duration`. Unset defers to csi-lib's default.
 #### **app.driver.csiDataDir** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -393,7 +393,8 @@ Random jitter applied as +/- this fraction of the current wait. Must be in [0, 1
 > null
 > ```
 
-Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be >= `duration`. Unset defers to csi-lib's default.
+Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be 0 (uncapped) or >=  
+`duration`. Unset defers to csi-lib's default.
 #### **app.driver.csiDataDir** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -383,7 +383,7 @@ Examples:
 #### **app.driver.gateBackoff.cap** ~ `string`
 > Default value:
 > ```yaml
-> 10s
+> 60s
 > ```
 #### **app.driver.csiDataDir** ~ `string`
 > Default value:

--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -365,36 +365,33 @@ Examples:
   - "pod-ip:ipv6"  
   - "pod-condition:NetworkAttached=True"  
   - "pod-annotation:k8s.v1.cni.cncf.io/networks-status"
-#### **app.driver.gateBackoff.duration** ~ `unknown`
-> Default value:
-> ```yaml
-> null
-> ```
+#### **app.driver.gateBackoff.duration** ~ `string`
 
-Base duration between gate-pending retries. The wait between the first failed gate check and the next attempt. Unset defers to csi-lib's default.
-#### **app.driver.gateBackoff.factor** ~ `unknown`
-> Default value:
-> ```yaml
-> null
-> ```
+Base duration between gate-pending retries. The wait between the first failed gate check and the next attempt.
 
-Multiplier applied to the previous wait after each failed gate check. Must be >= 1. With factor=1, the wait stays constant at `duration`.  
-Unset defers to csi-lib's default.
-#### **app.driver.gateBackoff.jitter** ~ `unknown`
-> Default value:
-> ```yaml
-> null
-> ```
+#### **app.driver.gateBackoff.factor** ~ `number`
 
-Random jitter applied as +/- this fraction of the current wait. Must be in [0, 1]. With jitter=0, retries are deterministic. Unset defers to csi-lib's default.
-#### **app.driver.gateBackoff.cap** ~ `unknown`
-> Default value:
-> ```yaml
-> null
-> ```
+Multiplier applied to the previous wait after each failed gate check. Must be >= 1. With factor=1, the wait stays constant at `duration`.
+
+#### **app.driver.gateBackoff.jitter** ~ `number`
+
+Random jitter applied as +/- this fraction of the current wait. Must be in [0, 1]. With jitter=0, retries are deterministic. NOTE: jitter=0 cannot be set via this chart (the template only renders the flag when truthy, so 0 is indistinguishable from unset here); use --gate-backoff-jitter=0 directly on the binary if you need this.
+
+#### **app.driver.gateBackoff.cap** ~ `string`
 
 Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be 0 (uncapped) or >=  
-`duration`. Unset defers to csi-lib's default.
+`duration`. NOTE: cap=0 (uncapped) cannot be set via this chart (the  
+template only renders the flag when truthy, so 0 is indistinguishable from unset here); use --gate-backoff-cap=0 directly on the binary if you need this.
+
+#### **app.driver.gateBackoff** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Backoff applied between gate-pending retries (i.e. when ReadyToRequest reports a readiness gate is not yet met). Distinct from csi-lib's renewal backoff, which protects against signer failures and is left at csi-lib's defaults. Leave *all* four fields above commented out to defer entirely to csi-lib's own GateBackoffConfig defaults instead of pinning to a copy of them here.  
+  
+NOTE this is all-or-nothing, not per-field: uncommenting *any one* field above pins all four fields (including any left commented out, which fall back to the CLI's own defaults, not csi-lib's) to the CLI's current values for the driver's lifetime. Only set a field here to intentionally override csi-lib's tuning for a slower or faster gate-resolution profile; be aware that doing so also freezes the other three fields at today's CLI defaults even if csi-lib's own defaults change in a future release.
 #### **app.driver.csiDataDir** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -99,10 +99,8 @@ spec:
             - --continue-on-not-ready={{ .Values.app.driver.continueOnNotReady }}
             - --kube-api-qps={{ .Values.app.driver.kubernetesAPIQPS }}
             - --kube-api-burst={{ .Values.app.driver.kubernetesAPIBurst }}
-{{- if .Values.app.driver.podReadinessGates }}
 {{- range .Values.app.driver.podReadinessGates }}
             - --pod-readiness-gate={{ . }}
-{{- end }}
 {{- end }}
 {{- /*
 Only render the flags an operator actually set. csi-driver only builds a

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -108,16 +108,16 @@ GateBackoffConfig when one of these flags is present on argv (see
 cmd/app/app.go's use of FlagSet.Changed), deferring to csi-lib's own
 defaults otherwise.
 */}}
-{{- if ne (typeOf .Values.app.driver.gateBackoff.duration) "<nil>" }}
+{{- if .Values.app.driver.gateBackoff.duration }}
             - --gate-backoff-duration={{ .Values.app.driver.gateBackoff.duration }}
 {{- end }}
-{{- if ne (typeOf .Values.app.driver.gateBackoff.factor) "<nil>" }}
+{{- if .Values.app.driver.gateBackoff.factor }}
             - --gate-backoff-factor={{ .Values.app.driver.gateBackoff.factor }}
 {{- end }}
-{{- if ne (typeOf .Values.app.driver.gateBackoff.jitter) "<nil>" }}
+{{- if .Values.app.driver.gateBackoff.jitter }}
             - --gate-backoff-jitter={{ .Values.app.driver.gateBackoff.jitter }}
 {{- end }}
-{{- if ne (typeOf .Values.app.driver.gateBackoff.cap) "<nil>" }}
+{{- if .Values.app.driver.gateBackoff.cap }}
             - --gate-backoff-cap={{ .Values.app.driver.gateBackoff.cap }}
 {{- end }}
 {{- if .Values.metrics.enabled }}

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -99,8 +99,14 @@ spec:
             - --continue-on-not-ready={{ .Values.app.driver.continueOnNotReady }}
             - --kube-api-qps={{ .Values.app.driver.kubernetesAPIQPS }}
             - --kube-api-burst={{ .Values.app.driver.kubernetesAPIBurst }}
+{{- if .Values.app.driver.podReadinessGates }}
 {{- range .Values.app.driver.podReadinessGates }}
             - --pod-readiness-gate={{ . }}
+{{- end }}
+            - --gate-backoff-duration={{ .Values.app.driver.gateBackoff.duration }}
+            - --gate-backoff-factor={{ .Values.app.driver.gateBackoff.factor }}
+            - --gate-backoff-jitter={{ .Values.app.driver.gateBackoff.jitter }}
+            - --gate-backoff-cap={{ .Values.app.driver.gateBackoff.cap }}
 {{- end }}
 {{- if .Values.metrics.enabled }}
             - --metrics-bind-address=:{{ .Values.metrics.port }}

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -103,9 +103,23 @@ spec:
 {{- range .Values.app.driver.podReadinessGates }}
             - --pod-readiness-gate={{ . }}
 {{- end }}
+{{- end }}
+{{- /*
+Only render the flags an operator actually set. csi-driver only builds a
+GateBackoffConfig when one of these flags is present on argv (see
+cmd/app/app.go's use of FlagSet.Changed), deferring to csi-lib's own
+defaults otherwise.
+*/}}
+{{- if ne (typeOf .Values.app.driver.gateBackoff.duration) "<nil>" }}
             - --gate-backoff-duration={{ .Values.app.driver.gateBackoff.duration }}
+{{- end }}
+{{- if ne (typeOf .Values.app.driver.gateBackoff.factor) "<nil>" }}
             - --gate-backoff-factor={{ .Values.app.driver.gateBackoff.factor }}
+{{- end }}
+{{- if ne (typeOf .Values.app.driver.gateBackoff.jitter) "<nil>" }}
             - --gate-backoff-jitter={{ .Values.app.driver.gateBackoff.jitter }}
+{{- end }}
+{{- if ne (typeOf .Values.app.driver.gateBackoff.cap) "<nil>" }}
             - --gate-backoff-cap={{ .Values.app.driver.gateBackoff.cap }}
 {{- end }}
 {{- if .Values.metrics.enabled }}

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -98,6 +98,9 @@
         "csiDataDir": {
           "$ref": "#/$defs/helm-values.app.driver.csiDataDir"
         },
+        "gateBackoff": {
+          "$ref": "#/$defs/helm-values.app.driver.gateBackoff"
+        },
         "kubernetesAPIBurst": {
           "$ref": "#/$defs/helm-values.app.driver.kubernetesAPIBurst"
         },
@@ -125,6 +128,40 @@
       "default": "/tmp/cert-manager-csi-driver",
       "description": "Configures the hostPath directory that the driver writes and mounts volumes from.",
       "type": "string"
+    },
+    "helm-values.app.driver.gateBackoff": {
+      "additionalProperties": false,
+      "properties": {
+        "cap": {
+          "$ref": "#/$defs/helm-values.app.driver.gateBackoff.cap"
+        },
+        "duration": {
+          "$ref": "#/$defs/helm-values.app.driver.gateBackoff.duration"
+        },
+        "factor": {
+          "$ref": "#/$defs/helm-values.app.driver.gateBackoff.factor"
+        },
+        "jitter": {
+          "$ref": "#/$defs/helm-values.app.driver.gateBackoff.jitter"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.driver.gateBackoff.cap": {
+      "default": "10s",
+      "type": "string"
+    },
+    "helm-values.app.driver.gateBackoff.duration": {
+      "default": "1s",
+      "type": "string"
+    },
+    "helm-values.app.driver.gateBackoff.factor": {
+      "default": 2,
+      "type": "number"
+    },
+    "helm-values.app.driver.gateBackoff.jitter": {
+      "default": 0.5,
+      "type": "number"
     },
     "helm-values.app.driver.kubernetesAPIBurst": {
       "default": 0,

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -148,7 +148,7 @@
       "type": "object"
     },
     "helm-values.app.driver.gateBackoff.cap": {
-      "default": "10s",
+      "default": "60s",
       "type": "string"
     },
     "helm-values.app.driver.gateBackoff.duration": {

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -148,24 +148,16 @@
       "type": "object"
     },
     "helm-values.app.driver.gateBackoff.cap": {
-      "default": "10s",
-      "description": "Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be >= `duration`.",
-      "type": "string"
+      "description": "Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be >= `duration`. Unset defers to csi-lib's default."
     },
     "helm-values.app.driver.gateBackoff.duration": {
-      "default": "1s",
-      "description": "Base duration between gate-pending retries. The wait between the first failed gate check and the next attempt.",
-      "type": "string"
+      "description": "Base duration between gate-pending retries. The wait between the first failed gate check and the next attempt. Unset defers to csi-lib's default."
     },
     "helm-values.app.driver.gateBackoff.factor": {
-      "default": 2,
-      "description": "Multiplier applied to the previous wait after each failed gate check. Must be >= 1. With factor=1, the wait stays constant at `duration`.",
-      "type": "number"
+      "description": "Multiplier applied to the previous wait after each failed gate check. Must be >= 1. With factor=1, the wait stays constant at `duration`.\nUnset defers to csi-lib's default."
     },
     "helm-values.app.driver.gateBackoff.jitter": {
-      "default": 0.5,
-      "description": "Random jitter applied as +/- this fraction of the current wait. Must be in [0, 1]. With jitter=0, retries are deterministic.",
-      "type": "number"
+      "description": "Random jitter applied as +/- this fraction of the current wait. Must be in [0, 1]. With jitter=0, retries are deterministic. Unset defers to csi-lib's default."
     },
     "helm-values.app.driver.kubernetesAPIBurst": {
       "default": 0,

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -148,19 +148,23 @@
       "type": "object"
     },
     "helm-values.app.driver.gateBackoff.cap": {
-      "default": "60s",
+      "default": "10s",
+      "description": "Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be >= `duration`.",
       "type": "string"
     },
     "helm-values.app.driver.gateBackoff.duration": {
       "default": "1s",
+      "description": "Base duration between gate-pending retries. The wait between the first failed gate check and the next attempt.",
       "type": "string"
     },
     "helm-values.app.driver.gateBackoff.factor": {
       "default": 2,
+      "description": "Multiplier applied to the previous wait after each failed gate check. Must be >= 1. With factor=1, the wait stays constant at `duration`.",
       "type": "number"
     },
     "helm-values.app.driver.gateBackoff.jitter": {
       "default": 0.5,
+      "description": "Random jitter applied as +/- this fraction of the current wait. Must be in [0, 1]. With jitter=0, retries are deterministic.",
       "type": "number"
     },
     "helm-values.app.driver.kubernetesAPIBurst": {

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -131,6 +131,8 @@
     },
     "helm-values.app.driver.gateBackoff": {
       "additionalProperties": false,
+      "default": {},
+      "description": "Backoff applied between gate-pending retries (i.e. when ReadyToRequest reports a readiness gate is not yet met). Distinct from csi-lib's renewal backoff, which protects against signer failures and is left at csi-lib's defaults. Leave *all* four fields above commented out to defer entirely to csi-lib's own GateBackoffConfig defaults instead of pinning to a copy of them here.\n\nNOTE this is all-or-nothing, not per-field: uncommenting *any one* field above pins all four fields (including any left commented out, which fall back to the CLI's own defaults, not csi-lib's) to the CLI's current values for the driver's lifetime. Only set a field here to intentionally override csi-lib's tuning for a slower or faster gate-resolution profile; be aware that doing so also freezes the other three fields at today's CLI defaults even if csi-lib's own defaults change in a future release.",
       "properties": {
         "cap": {
           "$ref": "#/$defs/helm-values.app.driver.gateBackoff.cap"
@@ -148,16 +150,20 @@
       "type": "object"
     },
     "helm-values.app.driver.gateBackoff.cap": {
-      "description": "Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be 0 (uncapped) or >=\n`duration`. Unset defers to csi-lib's default."
+      "description": "Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be 0 (uncapped) or >=\n`duration`. NOTE: cap=0 (uncapped) cannot be set via this chart (the\ntemplate only renders the flag when truthy, so 0 is indistinguishable from unset here); use --gate-backoff-cap=0 directly on the binary if you need this.",
+      "type": "string"
     },
     "helm-values.app.driver.gateBackoff.duration": {
-      "description": "Base duration between gate-pending retries. The wait between the first failed gate check and the next attempt. Unset defers to csi-lib's default."
+      "description": "Base duration between gate-pending retries. The wait between the first failed gate check and the next attempt.",
+      "type": "string"
     },
     "helm-values.app.driver.gateBackoff.factor": {
-      "description": "Multiplier applied to the previous wait after each failed gate check. Must be >= 1. With factor=1, the wait stays constant at `duration`.\nUnset defers to csi-lib's default."
+      "description": "Multiplier applied to the previous wait after each failed gate check. Must be >= 1. With factor=1, the wait stays constant at `duration`.",
+      "type": "number"
     },
     "helm-values.app.driver.gateBackoff.jitter": {
-      "description": "Random jitter applied as +/- this fraction of the current wait. Must be in [0, 1]. With jitter=0, retries are deterministic. Unset defers to csi-lib's default."
+      "description": "Random jitter applied as +/- this fraction of the current wait. Must be in [0, 1]. With jitter=0, retries are deterministic. NOTE: jitter=0 cannot be set via this chart (the template only renders the flag when truthy, so 0 is indistinguishable from unset here); use --gate-backoff-jitter=0 directly on the binary if you need this.",
+      "type": "number"
     },
     "helm-values.app.driver.kubernetesAPIBurst": {
       "default": 0,

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -148,7 +148,7 @@
       "type": "object"
     },
     "helm-values.app.driver.gateBackoff.cap": {
-      "description": "Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be >= `duration`. Unset defers to csi-lib's default."
+      "description": "Upper bound on the wait between gate-pending retries; the exponential growth from `factor` is capped here. Must be 0 (uncapped) or >=\n`duration`. Unset defers to csi-lib's default."
     },
     "helm-values.app.driver.gateBackoff.duration": {
       "description": "Base duration between gate-pending retries. The wait between the first failed gate check and the next attempt. Unset defers to csi-lib's default."

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -245,10 +245,18 @@ app:
     # GateBackoffConfig; override to tune polling cadence for slower or
     # faster gate-resolution profiles.
     gateBackoff:
+      # Base duration between gate-pending retries. The wait between the first
+      # failed gate check and the next attempt.
       duration: 1s
+      # Multiplier applied to the previous wait after each failed gate check.
+      # Must be >= 1. With factor=1, the wait stays constant at `duration`.
       factor: 2.0
+      # Random jitter applied as +/- this fraction of the current wait. Must be
+      # in [0, 1]. With jitter=0, retries are deterministic.
       jitter: 0.5
-      cap: 60s
+      # Upper bound on the wait between gate-pending retries; the exponential
+      # growth from `factor` is capped here. Must be >= `duration`.
+      cap: 10s
     # Configures the hostPath directory that the driver writes and mounts volumes from.
     csiDataDir: /tmp/cert-manager-csi-driver
   # Options for the liveness container.

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -238,36 +238,49 @@ app:
     #   - "pod-condition:NetworkAttached=True"
     #   - "pod-annotation:k8s.v1.cni.cncf.io/networks-status"
     podReadinessGates: []
+    # Base duration between gate-pending retries. The wait between the first
+    # failed gate check and the next attempt.
+    # +docs:property=app.driver.gateBackoff.duration
+    # duration: 1s
+
+    # Multiplier applied to the previous wait after each failed gate check.
+    # Must be >= 1. With factor=1, the wait stays constant at `duration`.
+    # +docs:property=app.driver.gateBackoff.factor
+    # factor: 2.0
+
+    # Random jitter applied as +/- this fraction of the current wait. Must be
+    # in [0, 1]. With jitter=0, retries are deterministic. NOTE: jitter=0
+    # cannot be set via this chart (the template only renders the flag when
+    # truthy, so 0 is indistinguishable from unset here); use --gate-backoff-jitter=0
+    # directly on the binary if you need this.
+    # +docs:property=app.driver.gateBackoff.jitter
+    # jitter: 0.5
+
+    # Upper bound on the wait between gate-pending retries; the exponential
+    # growth from `factor` is capped here. Must be 0 (uncapped) or >=
+    # `duration`. NOTE: cap=0 (uncapped) cannot be set via this chart (the
+    # template only renders the flag when truthy, so 0 is indistinguishable
+    # from unset here); use --gate-backoff-cap=0 directly on the binary if
+    # you need this.
+    # +docs:property=app.driver.gateBackoff.cap
+    # cap: 10s
+
     # Backoff applied between gate-pending retries (i.e. when ReadyToRequest
     # reports a readiness gate is not yet met). Distinct from csi-lib's
     # renewal backoff, which protects against signer failures and is left at
-    # csi-lib's defaults. Leave *all* of the fields below unset (null) to
+    # csi-lib's defaults. Leave *all* four fields above commented out to
     # defer entirely to csi-lib's own GateBackoffConfig defaults instead of
     # pinning to a copy of them here.
     #
-    # NOTE this is all-or-nothing, not per-field: setting *any one* field
-    # below pins all four fields (including any left null, which fall back to
-    # the CLI's own defaults, not csi-lib's) to the CLI's current values for
-    # the driver's lifetime. Only set a field here to intentionally override
-    # csi-lib's tuning for a slower or faster gate-resolution profile; be
-    # aware that doing so also freezes the other three fields at today's CLI
-    # defaults even if csi-lib's own defaults change in a future release.
-    gateBackoff:
-      # Base duration between gate-pending retries. The wait between the first
-      # failed gate check and the next attempt. Unset defers to csi-lib's default.
-      duration: null
-      # Multiplier applied to the previous wait after each failed gate check.
-      # Must be >= 1. With factor=1, the wait stays constant at `duration`.
-      # Unset defers to csi-lib's default.
-      factor: null
-      # Random jitter applied as +/- this fraction of the current wait. Must be
-      # in [0, 1]. With jitter=0, retries are deterministic. Unset defers to
-      # csi-lib's default.
-      jitter: null
-      # Upper bound on the wait between gate-pending retries; the exponential
-      # growth from `factor` is capped here. Must be 0 (uncapped) or >=
-      # `duration`. Unset defers to csi-lib's default.
-      cap: null
+    # NOTE this is all-or-nothing, not per-field: uncommenting *any one*
+    # field above pins all four fields (including any left commented out,
+    # which fall back to the CLI's own defaults, not csi-lib's) to the CLI's
+    # current values for the driver's lifetime. Only set a field here to
+    # intentionally override csi-lib's tuning for a slower or faster
+    # gate-resolution profile; be aware that doing so also freezes the other
+    # three fields at today's CLI defaults even if csi-lib's own defaults
+    # change in a future release.
+    gateBackoff: {}
     # Configures the hostPath directory that the driver writes and mounts volumes from.
     csiDataDir: /tmp/cert-manager-csi-driver
   # Options for the liveness container.

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -241,22 +241,26 @@ app:
     # Backoff applied between gate-pending retries (i.e. when ReadyToRequest
     # reports a readiness gate is not yet met). Distinct from csi-lib's
     # renewal backoff, which protects against signer failures and is left at
-    # csi-lib's defaults. Values below mirror csi-lib's own defaults for
-    # GateBackoffConfig; override to tune polling cadence for slower or
-    # faster gate-resolution profiles.
+    # csi-lib's defaults. Leave any of the fields below unset (null) to defer
+    # to csi-lib's own GateBackoffConfig defaults instead of pinning to a
+    # copy of them here — only set a field to override csi-lib's tuning for
+    # slower or faster gate-resolution profiles.
     gateBackoff:
       # Base duration between gate-pending retries. The wait between the first
-      # failed gate check and the next attempt.
-      duration: 1s
+      # failed gate check and the next attempt. Unset defers to csi-lib's default.
+      duration: null
       # Multiplier applied to the previous wait after each failed gate check.
       # Must be >= 1. With factor=1, the wait stays constant at `duration`.
-      factor: 2.0
+      # Unset defers to csi-lib's default.
+      factor: null
       # Random jitter applied as +/- this fraction of the current wait. Must be
-      # in [0, 1]. With jitter=0, retries are deterministic.
-      jitter: 0.5
+      # in [0, 1]. With jitter=0, retries are deterministic. Unset defers to
+      # csi-lib's default.
+      jitter: null
       # Upper bound on the wait between gate-pending retries; the exponential
-      # growth from `factor` is capped here. Must be >= `duration`.
-      cap: 10s
+      # growth from `factor` is capped here. Must be >= `duration`. Unset
+      # defers to csi-lib's default.
+      cap: null
     # Configures the hostPath directory that the driver writes and mounts volumes from.
     csiDataDir: /tmp/cert-manager-csi-driver
   # Options for the liveness container.

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -238,6 +238,17 @@ app:
     #   - "pod-condition:NetworkAttached=True"
     #   - "pod-annotation:k8s.v1.cni.cncf.io/networks-status"
     podReadinessGates: []
+    # Backoff applied between gate-pending retries (i.e. when ReadyToRequest
+    # reports a readiness gate is not yet met). Distinct from csi-lib's
+    # renewal backoff, which protects against signer failures and is left at
+    # csi-lib's defaults. Values below mirror csi-lib's own defaults for
+    # GateBackoffConfig; override to tune polling cadence for slower or
+    # faster gate-resolution profiles.
+    gateBackoff:
+      duration: 1s
+      factor: 2.0
+      jitter: 0.5
+      cap: 60s
     # Configures the hostPath directory that the driver writes and mounts volumes from.
     csiDataDir: /tmp/cert-manager-csi-driver
   # Options for the liveness container.

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -241,10 +241,17 @@ app:
     # Backoff applied between gate-pending retries (i.e. when ReadyToRequest
     # reports a readiness gate is not yet met). Distinct from csi-lib's
     # renewal backoff, which protects against signer failures and is left at
-    # csi-lib's defaults. Leave any of the fields below unset (null) to defer
-    # to csi-lib's own GateBackoffConfig defaults instead of pinning to a
-    # copy of them here — only set a field to override csi-lib's tuning for
-    # slower or faster gate-resolution profiles.
+    # csi-lib's defaults. Leave *all* of the fields below unset (null) to
+    # defer entirely to csi-lib's own GateBackoffConfig defaults instead of
+    # pinning to a copy of them here.
+    #
+    # NOTE this is all-or-nothing, not per-field: setting *any one* field
+    # below pins all four fields (including any left null, which fall back to
+    # the CLI's own defaults, not csi-lib's) to the CLI's current values for
+    # the driver's lifetime. Only set a field here to intentionally override
+    # csi-lib's tuning for a slower or faster gate-resolution profile; be
+    # aware that doing so also freezes the other three fields at today's CLI
+    # defaults even if csi-lib's own defaults change in a future release.
     gateBackoff:
       # Base duration between gate-pending retries. The wait between the first
       # failed gate check and the next attempt. Unset defers to csi-lib's default.

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -258,8 +258,8 @@ app:
       # csi-lib's default.
       jitter: null
       # Upper bound on the wait between gate-pending retries; the exponential
-      # growth from `factor` is capped here. Must be >= `duration`. Unset
-      # defers to csi-lib's default.
+      # growth from `factor` is capped here. Must be 0 (uncapped) or >=
+      # `duration`. Unset defers to csi-lib's default.
       cap: null
     # Configures the hostPath directory that the driver writes and mounts volumes from.
     csiDataDir: /tmp/cert-manager-csi-driver


### PR DESCRIPTION
## Why

  csi-lib's renewal loop used a single backoff (`RenewalBackoffConfig`, default 30s base / 5min cap) for both genuine issuance failures (signer down, apiserver errors, denials) and `ReadyToRequestFunc` returning false. With `--pod-readiness-gate` configured, that cadence is wrong for the gate-pending case: the underlying condition
(CNI assigning a pod IP, a controller flipping a pod condition) typically resolves in seconds, but the driver was sleeping for 30+ seconds between checks. [csi-lib#235](https://github.com/cert-manager/csi-lib/pull/235) separated the two backoffs by adding `GateBackoffConfig`. This PR exposes that option to csi-driver operators.

## What this PR changes

  - **Four new CLI flags** on `cert-manager-csi-driver`, mirroring `wait.Backoff` fields:
    - `--gate-backoff-duration` (default `1s`)
    - `--gate-backoff-factor` (default `2.0`)
    - `--gate-backoff-jitter` (default `0.5`)
    - `--gate-backoff-cap` (default `10s`)
  - **Wiring in `cmd/app/app.go`**: `mgrOpts.GateBackoffConfig` is set from these flags

## Backwards compatibility

  - Deployments without `--pod-readiness-gate`: no behaviour change. `mgrOpts.GateBackoffConfig` is left nil, csi-lib uses its own defaults if
  - Deployments with `--pod-readiness-gate`: the gate-pending wait window drops from csi-lib's renewal-backoff cadence (~30s) to the gate-backoff cadence (~1s typical), which is the entire point of the change. 
  - Existing RenewalBackoffConfig behaviour is unchanged. Issuance errors still use the signer-protective backoff.

  Dependencies

  - go.mod currently points at a pseudo-version of csi-lib (v0.10.1-0.20260624100922-4eeba3e02d4e) covering the merge of csi-lib#235. Before merging this PR, the dependency should be bumped to a tagged csi-lib release containing #235 — happy to amend once a release is cut.