### PR TITLE
feat(chart): expose automountServiceAccountToken in the csi-driver chart

### DIFF
--- a/deploy/charts/csi-driver/README.md
+++ b/deploy/charts/csi-driver/README.md
@@ -407,6 +407,14 @@ Optional additional annotations to add to the csi-driver pods.
 > ```
 
 Optional additional labels to add to the csi-driver pods.
+#### **automountServiceAccountToken** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Automounting API credentials for the csi-driver pod.
+
 #### **resources** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver/templates/daemonset.yaml
@@ -35,6 +35,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "cert-manager-csi-driver.name" . }}
+      {{- if hasKey .Values "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/deploy/charts/csi-driver/values.schema.json
+++ b/deploy/charts/csi-driver/values.schema.json
@@ -9,6 +9,9 @@
         "app": {
           "$ref": "#/$defs/helm-values.app"
         },
+        "automountServiceAccountToken": {
+          "$ref": "#/$defs/helm-values.automountServiceAccountToken"
+        },
         "commonLabels": {
           "$ref": "#/$defs/helm-values.commonLabels"
         },
@@ -175,6 +178,11 @@
       "default": 1,
       "description": "Verbosity of cert-manager-csi-driver logging.",
       "type": "number"
+    },
+    "helm-values.automountServiceAccountToken": {
+      "default": true,
+      "description": "Automounting API credentials for the csi-driver pod.",
+      "type": "boolean"
     },
     "helm-values.commonLabels": {
       "default": {},

--- a/deploy/charts/csi-driver/values.yaml
+++ b/deploy/charts/csi-driver/values.yaml
@@ -256,6 +256,10 @@ podAnnotations: {}
 # Optional additional labels to add to the csi-driver pods.
 podLabels: {}
 
+# Automounting API credentials for the csi-driver pod.
+# +docs:property
+automountServiceAccountToken: true
+
 # Kubernetes pod resources requests/limits for cert-manager-csi-driver.
 #
 # For example:


### PR DESCRIPTION
## What
Adds an `automountServiceAccountToken` value to the csi-driver chart so operators can disable automatic mounting of the ServiceAccount token on the csi-driver pod — a common security-hardening request, matching the option already in the trust-manager chart.

## Details
- New `automountServiceAccountToken` value (defaults to `true`, preserving current behaviour).
- Rendered on the DaemonSet pod spec via `{{- if hasKey .Values "automountServiceAccountToken" }}`.
- Regenerated `values.schema.json` and `README.md` with `helm-tool`.

`helm lint` passes; `helm template --set automountServiceAccountToken=false` renders the field correctly.