### PR TITLE
chore: update livenessprobe to v2.19.0 and csi-node-driver-registrar to v2.17.0

### DIFF
--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -43,11 +43,11 @@ golangci_lint_config := .golangci.yaml
 
 livenessprobe_image_name_source := registry.k8s.io/sig-storage/livenessprobe
 livenessprobe_image_name := quay.io/jetstack/livenessprobe
-livenessprobe_image_tag := v2.18.0
+livenessprobe_image_tag := v2.19.0
 
 nodedriverregistrar_image_name_source := registry.k8s.io/sig-storage/csi-node-driver-registrar
 nodedriverregistrar_image_name := quay.io/jetstack/csi-node-driver-registrar
-nodedriverregistrar_image_tag := v2.16.0
+nodedriverregistrar_image_tag := v2.17.0
 
 define helm_values_mutation_function
 $(YQ) \


### PR DESCRIPTION
Pre-release checklist item from RELEASE.md: update the sidecar images that are copied to `quay.io/jetstack` during the release.

- `livenessprobe`: v2.18.0 → v2.19.0
- `csi-node-driver-registrar`: v2.16.0 → v2.17.0

Both are the latest versions on `registry.k8s.io/sig-storage`. Renovate does not manage these tags.