### PR TITLE
Parse comma separated volume attributes as CSV

### DIFF
--- a/pkg/requestgen/generator.go
+++ b/pkg/requestgen/generator.go
@@ -19,6 +19,7 @@ package requestgen
 import (
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"net"
@@ -116,6 +117,11 @@ func RequestForMetadata(meta metadata.Metadata) (*manager.CertificateRequestBund
 		return nil, fmt.Errorf("%q: %w", csiapi.URISANsKey, err)
 	}
 
+	usages, err := keyUsagesFromAttributes(attrs[csiapi.KeyUsagesKey])
+	if err != nil {
+		return nil, fmt.Errorf("%q: %w", csiapi.KeyUsagesKey, err)
+	}
+
 	annotations := make(map[string]string)
 	for key, val := range attrs {
 		group, _, found := strings.Cut(key, "/")
@@ -134,7 +140,7 @@ func RequestForMetadata(meta metadata.Metadata) (*manager.CertificateRequestBund
 		IsCA:      strings.ToLower(attrs[csiapi.IsCAKey]) == "true",
 		Namespace: attrs[csiapi.K8sVolumeContextKeyPodNamespace],
 		Duration:  duration,
-		Usages:    keyUsagesFromAttributes(attrs[csiapi.KeyUsagesKey]),
+		Usages:    usages,
 		IssuerRef: cmmeta.IssuerReference{
 			Name:  attrs[csiapi.IssuerNameKey],
 			Kind:  attrs[csiapi.IssuerKindKey],
@@ -154,7 +160,7 @@ func parseDNSNames(meta metadata.Metadata, dnsNames string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return splitList(dns), nil
+	return splitList(dns)
 }
 
 // parseIPAddresses parses a csi.cert-manager.io/ip-sans value, and returns the
@@ -164,9 +170,14 @@ func parseIPAddresses(ipCSV string) ([]net.IP, error) {
 		return nil, nil
 	}
 
+	ipStrs, err := splitList(ipCSV)
+	if err != nil {
+		return nil, err
+	}
+
 	var ips []net.IP
 	var errs []string
-	for _, ipStr := range splitList(ipCSV) {
+	for _, ipStr := range ipStrs {
 		ip := net.ParseIP(ipStr)
 		if ip == nil {
 			errs = append(errs, ipStr)
@@ -194,10 +205,15 @@ func parseURIs(meta metadata.Metadata, uriCSV string) ([]*url.URL, error) {
 		return nil, err
 	}
 
+	rawURIs, err := splitList(csv)
+	if err != nil {
+		return nil, err
+	}
+
 	var uris []*url.URL
 	var errs []string
 
-	for _, rawURI := range splitList(csv) {
+	for _, rawURI := range rawURIs {
 		uri, err := url.ParseRequestURI(rawURI)
 		if err != nil {
 			errs = append(errs, err.Error())
@@ -215,17 +231,22 @@ func parseURIs(meta metadata.Metadata, uriCSV string) ([]*url.URL, error) {
 }
 
 // keyUsagesFromAttributes returns the set of key usages from the given CSV.
-func keyUsagesFromAttributes(usagesCSV string) []cmapi.KeyUsage {
+func keyUsagesFromAttributes(usagesCSV string) ([]cmapi.KeyUsage, error) {
 	if len(usagesCSV) == 0 {
-		return nil
+		return nil, nil
+	}
+
+	usages, err := splitList(usagesCSV)
+	if err != nil {
+		return nil, err
 	}
 
 	var keyUsages []cmapi.KeyUsage
-	for _, usage := range splitList(usagesCSV) {
+	for _, usage := range usages {
 		keyUsages = append(keyUsages, cmapi.KeyUsage(usage))
 	}
 
-	return keyUsages
+	return keyUsages, nil
 }
 
 // expand executes os.Expand on the given csv with volume context variables
@@ -257,11 +278,30 @@ func expand(meta metadata.Metadata, csv string) (string, error) {
 	return exp, nil
 }
 
-// splitList returns the given csv as a slice. Trims space of each element.
-func splitList(csv string) []string {
-	var list []string
-	for s := range strings.SplitSeq(csv, ",") {
-		list = append(list, strings.TrimSpace(s))
+// splitList returns the given csv as a slice, trimming space around each
+// element.
+//
+// The value is read as a single CSV record, so an element that needs to
+// contain a comma can be quoted: `"a,b",c` gives ["a,b", "c"]. Plain values
+// are unaffected.
+func splitList(value string) ([]string, error) {
+	// These values are often spread over several lines in a manifest, where
+	// the newlines are only formatting. Fold them into spaces so the reader
+	// sees a single record rather than several.
+	folded := strings.NewReplacer("\r\n", " ", "\r", " ", "\n", " ").Replace(value)
+
+	reader := csv.NewReader(strings.NewReader(folded))
+	reader.TrimLeadingSpace = true
+	reader.FieldsPerRecord = -1
+
+	list, err := reader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %q as CSV: %w", value, err)
 	}
-	return list
+
+	for i, s := range list {
+		list[i] = strings.TrimSpace(s)
+	}
+
+	return list, nil
 }

--- a/pkg/requestgen/generator_test.go
+++ b/pkg/requestgen/generator_test.go
@@ -244,6 +244,11 @@ func Test_parseDNSNames(t *testing.T) {
 			expDNSNames: []string{"my-dns"},
 			expErr:      nil,
 		},
+		"a quoted entry containing a comma should be kept as one name": {
+			csv:         `"my,dns",my-second-dns`,
+			expDNSNames: []string{"my,dns", "my-second-dns"},
+			expErr:      nil,
+		},
 		"a csv with multiple entries should expect those entries returned": {
 			csv:         "my-dns,my-second-dns,my-third-dns",
 			expDNSNames: []string{"my-dns", "my-second-dns", "my-third-dns"},
@@ -317,7 +322,7 @@ func Test_URIs(t *testing.T) {
 		"a csv with a bad URI should return an error": {
 			csv:     "spiffe://foo.bar,\n\nx\n,foo://foo\nbar,file://hello-world/1234,1234",
 			expURIs: nil,
-			expErr:  errors.New(`parse "x": invalid URI for request, parse "foo://foo\nbar": net/url: invalid control character in URL, parse "1234": invalid URI for request`),
+			expErr:  errors.New(`parse "x": invalid URI for request, parse "foo://foo bar": invalid character " " in host name, parse "1234": invalid URI for request`),
 		},
 		"a single csv which uses variables should be substituted correctly": {
 			csv: `foo://$POD_NAME-my-dns-${POD_NAMESPACE}-${POD_UID}`,
@@ -332,6 +337,16 @@ func Test_URIs(t *testing.T) {
 			csv:     `$POD_NAME-my-dns-${POD_NAMESPACE}-$POD_UID-${Foo}`,
 			expURIs: nil,
 			expErr:  errors.New(`undefined variable "Foo", known variables: [POD_NAME POD_NAMESPACE POD_UID SERVICE_ACCOUNT_NAME]`),
+		},
+		"a quoted entry containing a comma should be kept as one URI": {
+			csv: `"spiffe://foo.bar/a,b",spiffe://foo.bar/c`,
+			expURIs: func(t *testing.T) []*url.URL {
+				return []*url.URL{
+					mustParse(t, "spiffe://foo.bar/a,b"),
+					mustParse(t, "spiffe://foo.bar/c"),
+				}
+			},
+			expErr: nil,
 		},
 		"a csv containing multiple entries which uses variables should be substituted correctly": {
 			csv: `spiffe://$POD_NAME-my-dns-${POD_NAMESPACE}-$POD_UID,spiffe://$POD_NAME,file://${POD_NAME}.$POD_NAMESPACE,foo://$POD_NAME.$POD_NAMESPACE.svc,spiffe://$POD_UID`,
@@ -404,5 +419,57 @@ func baseMetadata() metadata.Metadata {
 			"csi.storage.k8s.io/serviceAccount.name": "my-service-account",
 			"csi.storage.k8s.io/ephemeral":           "true",
 		},
+	}
+}
+
+func Test_splitList(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		value   string
+		expList []string
+		expErr  string
+	}{
+		"a single value is returned as one element": {
+			value:   "foo",
+			expList: []string{"foo"},
+		},
+		"values are split on commas": {
+			value:   "foo,bar,baz",
+			expList: []string{"foo", "bar", "baz"},
+		},
+		"space around each value is trimmed": {
+			value:   "foo,   bar,\tbaz  ",
+			expList: []string{"foo", "bar", "baz"},
+		},
+		"newlines are treated as space, not as a new record": {
+			value:   "foo,\n \t bar,\nbaz",
+			expList: []string{"foo", "bar", "baz"},
+		},
+		"a quoted value may contain a comma": {
+			value:   `"foo,bar",baz`,
+			expList: []string{"foo,bar", "baz"},
+		},
+		"a quoted value may contain a quote": {
+			value:   `"foo""bar",baz`,
+			expList: []string{`foo"bar`, "baz"},
+		},
+		"an unterminated quote is an error": {
+			value:  `"foo,bar`,
+			expErr: `failed to parse "\"foo,bar" as CSV: parse error on line 1, column 9: extraneous or missing " in quoted-field`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := splitList(test.value)
+			if test.expErr != "" {
+				assert.EqualError(t, err, test.expErr)
+				assert.Nil(t, got)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.expList, got)
+		})
 	}
 }


### PR DESCRIPTION
Fixes #256.

`splitList` split the value on every comma with no way to escape one, so a DNS name, IP, URI or key usage that legally contains a comma got torn into pieces. This reads the value as a single CSV record instead, so an element can be quoted:

```
csi.cert-manager.io/uri-sans: '"spiffe://foo.bar/a,b",spiffe://foo.bar/c'
```

now gives two URIs rather than three broken ones. Values without quotes behave exactly as before.

### Why not `cmutil.SplitWithEscapeCSV`

That is what the subject attributes use (`generator.go:99`), and reusing it was my first attempt, but it does not fit the other attributes. Two behaviours here are relied on and would have regressed:

* **Leading space is trimmed.** `SplitWithEscapeCSV` leaves it, and the existing tests cover a URI written as `,     foo://${POD_UID}` with five leading spaces.
* **Values may span several lines.** `SplitWithEscapeCSV` rejects that outright, and the existing tests cover `1.2.3.4,\n \t 5.6.7.8`, which is a normal way to write a long list in a manifest.

So this sets `TrimLeadingSpace`, trims each element, and folds newlines into spaces before parsing. Happy to revisit if you would rather have one shared helper and a change to `SplitWithEscapeCSV` upstream.

### Behaviour change worth flagging

A newline *inside* an element used to survive into the parsed value and is now treated as a space. The one place this shows up is an error message: `foo://foo\nbar` used to report `invalid control character in URL` and now reports `invalid character " " in host name`. The input is rejected either way, and the existing test expectation is updated accordingly.

### Testing

* New `Test_splitList` covering splitting, whitespace, newlines, a quoted comma, an escaped quote and an unterminated quote.
* New cases in `Test_URIs` and `Test_parseDNSNames` showing a quoted comma surviving end to end.
* Existing unit tests pass unchanged apart from the error string noted above.
* `go vet` and golangci-lint are clean. The e2e suite needs a live cluster so I have not run it.

```release-note
Volume attributes that take a comma separated list are now parsed as CSV, so an entry containing a comma can be quoted.
```
